### PR TITLE
Adjust About panel top spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 
   /* Panels */
   .ps-panel{position:absolute;inset:0;background:rgba(41,50,59,.96);display:flex;align-items:center;justify-content:center;opacity:0;transform:translateY(10px);transition:opacity .28s ease, transform .28s ease}
-  #panelAbout{padding:40px 0}
+  #panelAbout{padding:72px 0 40px}
   #panelAbout.is-scrollable{overflow:auto}
   #panelAbout.is-scrollable .ps-panel-inner{margin:40px auto}
   .ps-panel .ps-panel-inner{margin:auto;padding:34px 40px;line-height:1.9;max-width:860px;width:min(84vw, 860px);border:1px solid var(--line);border-radius:var(--radius);background:rgba(20,24,29,.78);display:grid;gap:30px;justify-items:center;text-align:center;box-shadow:var(--shadow)}


### PR DESCRIPTION
## Summary
- increase the top padding of the About panel to reduce the cramped feel above the content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d809afbc6c8325a9c48d32515b0b04