### PR TITLE
Add favicon using site logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Pentas Studio – Mock v27 (per-line color, no row gap, staggered + first-visit loader / About更新)</title>
+<link rel="icon" type="image/png" href="./image/logo.png" />
 <link href="https://fonts.googleapis.com/css2?family=Rampart+One&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@500;700&display=swap" rel="stylesheet">
 <style>


### PR DESCRIPTION
## Summary
- add a favicon link to reuse the existing logo image so the icon appears in browser tabs

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d917f4908c8325994ac2b9bf597c06