### PR TITLE
Refine games gallery layout

### DIFF
--- a/games/games.html
+++ b/games/games.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Games – Pentas Studio</title>
+  <link rel="icon" type="image/png" href="../image/general/logo.png" />
+  <link href="https://fonts.googleapis.com/css2?family=Rampart+One&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@500;700&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#29323b;
+      --surface:#1f2730;
+      --ink:#eff3f8;
+      --ink-weak:#aeb8c4;
+      --line:#394656;
+      --accent:#FFBA3A;
+      --radius:16px;
+      --shadow:0 10px 24px rgba(0,0,0,.35);
+      --page-pad:20px;
+    }
+
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0;
+      background:var(--bg);
+      color:var(--ink);
+      font-family:"Hiragino Kaku Gothic ProN","Noto Sans JP","BIZ UDGothic","Yu Gothic",Meiryo,sans-serif;
+    }
+    img{display:block;max-width:100%;height:auto;user-select:none;-webkit-user-drag:none}
+    a{color:inherit;text-decoration:none}
+    h1,h2,h3,p{margin:0}
+
+    .page{min-height:100vh;display:grid;grid-template-rows:auto 1fr auto}
+
+    header{padding:32px var(--page-pad) 20px;display:grid;gap:18px;justify-items:center;text-align:center;border-bottom:1px solid var(--line)}
+    .brand-logo{width:120px;height:120px;border-radius:50%;overflow:hidden;display:grid;place-items:center;background:transparent;border:1px solid var(--line)}
+    .brand-logo img{width:100%;height:100%;object-fit:contain}
+    .brand-name{font-family:'Rampart One',system-ui,sans-serif;font-size:32px;letter-spacing:.02em}
+    .brand-name img{max-height:78px;object-fit:contain;margin:0 auto}
+    .page-lead{max-width:720px;color:#e4eaf1;font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;line-height:1.7;font-size:16px;opacity:.92}
+
+    main{padding:40px var(--page-pad) 60px}
+    .gallery{width:100%;margin:0;display:grid;gap:24px}
+    .gallery-head{display:grid;gap:10px;justify-items:center;text-align:center;padding:0 var(--page-pad)}
+    .gallery-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:28px;letter-spacing:.12em}
+    .gallery-sub{color:var(--ink-weak);font-size:14px;letter-spacing:.08em;text-transform:uppercase}
+    .gallery-grid{display:grid;grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));gap:0;margin-inline:calc(-1 * var(--page-pad))}
+    .gallery-tile{position:relative;display:grid;place-items:center;transition:filter .18s ease;aspect-ratio:1;background:var(--tile-bg, transparent);overflow:hidden}
+    .gallery-tile:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
+    .gallery-tile img{width:100%;height:100%;object-fit:contain;vertical-align:middle}
+    .gallery-tile:hover img{filter:brightness(1.1)}
+    .gallery-tile.placeholder{background:linear-gradient(135deg, rgba(255,186,58,.18), rgba(31,39,48,.88));opacity:.28;pointer-events:none}
+    .gallery-tile.placeholder::after{content:"";position:absolute;inset:16%;border:1px dashed rgba(255,255,255,.28);border-radius:12px}
+
+    footer{padding:24px var(--page-pad) 34px;border-top:1px solid var(--line);display:flex;justify-content:center}
+    .sns{display:flex;gap:12px}
+    .sns a{width:46px;height:46px;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#ffffff12;border:1px solid var(--line);color:var(--ink);transition:transform .18s ease, background-color .18s ease, box-shadow .18s ease, color .18s ease;--sns-play:var(--bg)}
+    .sns a:hover{transform:scale(1.06);background:var(--accent);color:var(--bg);box-shadow:var(--shadow);border-color:transparent;--sns-play:var(--ink)}
+    .sns svg{width:20px;height:20px}
+    .sns path{fill:currentColor}
+    .sns path.play{fill:var(--sns-play);transition:fill .18s ease}
+
+    @media (max-width:639px){
+      :root{--page-pad:16px}
+      header{padding-top:28px}
+      .brand-name{font-size:28px}
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="brand-logo" href="../index.html" aria-label="トップページへ戻る">
+        <img src="../image/general/logo.png" alt="Pentas Studio" loading="lazy">
+      </a>
+      <div class="brand-name">
+        <img src="../image/general/let_logo.png" alt="Pentas Studio" loading="lazy">
+      </div>
+      <p class="page-lead">Pentas Studioがこれまでに手掛けてきた作品をまとめました。ボードゲームからマーダーミステリーまで、多彩なタイトルをご覧ください。</p>
+    </header>
+
+    <main>
+      <section class="gallery" aria-label="ゲームギャラリー">
+        <div class="gallery-head">
+          <div class="gallery-sub">Game Gallery</div>
+          <h1 class="gallery-title">ラインナップ</h1>
+        </div>
+        <div class="gallery-grid">
+          <a class="gallery-tile" href="#" aria-label="ゆめゆめ" style="--tile-bg:#202b38">
+            <img src="../image/games/yumeyume/comming.png" alt="ゆめゆめ" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="エスケープゴート" style="--tile-bg:#1f2b2f">
+            <img src="../image/games/escape-goat/escape.png" alt="エスケープゴート" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="静葬員" style="--tile-bg:#2f2937">
+            <img src="../image/games/seisoin/seisoin.png" alt="静葬員" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="名刺の管理ができません" style="--tile-bg:#2a2e2b">
+            <img src="../image/games/meishi/meishi.png" alt="名刺の管理ができません" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="インフォーマーリターンズ" style="--tile-bg:#192a3c">
+            <img src="../image/games/informer/informerR.png" alt="インフォーマーリターンズ" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="コミカルミッション" style="--tile-bg:#433148">
+            <img src="../image/games/comical/comical.png" alt="コミカルミッション" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="カチカン会談" style="--tile-bg:#352a33">
+            <img src="../image/games/kachikan/kachikan.png" alt="カチカン会談" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="アブセプチャー" style="--tile-bg:#2b3a4c">
+            <img src="../image/games/abcepture/abcepture.png" alt="アブセプチャー" loading="lazy">
+          </a>
+          <a class="gallery-tile" href="#" aria-label="インフォーマー" style="--tile-bg:#28334a">
+            <img src="../image/games/informer/informer.png" alt="インフォーマー" loading="lazy">
+          </a>
+          <span class="gallery-tile placeholder" aria-hidden="true"></span>
+          <span class="gallery-tile placeholder" aria-hidden="true"></span>
+          <span class="gallery-tile placeholder" aria-hidden="true"></span>
+        </div>
+      </section>
+    </main>
+
+    <footer aria-label="フッター">
+      <div class="sns" aria-label="SNSリンク">
+        <a href="https://x.com/bdg_de_asobo" aria-label="X" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18.244 3H21.5l-7.52 8.59L22 21h-6.31l-4.94-6.43L4.81 21H1.5l7.81-8.93L2 3h6.31l4.5 5.84L18.244 3Z"/>
+          </svg>
+        </a>
+        <a href="https://www.youtube.com/@%E3%83%9A%E3%83%B3%E3%82%BF%E3%82%B9%E3%82%B9%E3%82%BF%E3%82%B8%E3%82%AA" aria-label="YouTube" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M21.6 7.6a2 2 0 0 0-1.4-1.4C18.7 5.8 12 5.8 12 5.8s-6.7 0-8.2.4A2 2 0 0 0 2.4 7.6C2 9.1 2 12 2 12s0 2.9.4 4.4a2 2 0 0 0 1.4 1.4c1.5.4 8.2.4 8.2.4s6.7 0 8.2-.4a2 2 0 0 0 1.4-1.4c.4-1.5.4-4.4.4-4.4s0-2.9-.4-4.4Z"/>
+            <path class="play" d="M10.5 9.75v4.5L15 12l-4.5-2.25Z"/>
+          </svg>
+        </a>
+        <a href="https://pentasufide.booth.pm/" aria-label="BOOTH ショップ" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16l-1.2 8.4a2 2 0 0 1-2 1.6H8.2l-.4 2h10.7v2H6a1 1 0 0 1-1-.8L3 6Z"/>
+            <path d="M9 18H7.2L5.5 8h13l-.9 6.2a2 2 0 0 1-2 1.6H9Z"/>
+          </svg>
+        </a>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
       <section id="games" class="ps-section ps-games" aria-label="ゲーム一覧">
         <h2>GAMES</h2>
         <div class="ps-games-grid" id="gamesGrid"></div>
-        <div class="ps-games-actions"><a class="btn ps-games-more" href="#">More</a></div>
+        <div class="ps-games-actions"><a class="btn ps-games-more" href="games/games.html">More</a></div>
       </section>
 
       <section class="ps-section ps-members" aria-label="メンバー">
@@ -419,7 +419,7 @@ document.addEventListener('DOMContentLoaded', function(){
     {id:'escapegoat',  title:'エスケープゴート',       img:'image/games/escape-goat/escape.png',    link:'#game-escapegoat'},
     {id:'seisouin',    title:'静葬員',                 img:'image/games/seisoin/seisoin.png',   link:'#game-seisouin'},
     {id:'meishi',      title:'名刺の管理ができません', img:'image/games/meishi/meishi.png',    link:'#game-meishi'},
-    {id:'informer-rt', title:'インフォーマーR',        img:'image/games/informer/informerR.png', link:'#game-informer-r'},
+    {id:'informer-rt', title:'インフォーマーリターンズ', img:'image/games/informer/informerR.png', link:'#game-informer-r'},
     {id:'comical',     title:'コミカルミッション',     img:'image/games/comical/comical.png',   link:'#game-comical'},
     {id:'kachikan',    title:'カチカン会談',           img:'image/games/kachikan/kachikan.png',  link:'#game-kachikan'},
     {id:'abception',   title:'アブセプチャー',         img:'image/games/abcepture/abcepture.png', link:'#game-abception'},


### PR DESCRIPTION
## Summary
- remove the side gutters from the standalone games gallery and drive padding from a shared custom property
- reorder the gallery tiles to match the top page and add placeholders so rows stay visually balanced
- update the Informer Returns label to the full Japanese title so both pages stay consistent

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d92c41a67083259c9bd3fc6e88ffbb