### PR TITLE
Fix games gallery layout columns

### DIFF
--- a/games/games.html
+++ b/games/games.html
@@ -46,7 +46,10 @@
     .gallery-head{display:grid;gap:10px;justify-items:center;text-align:center;padding:0 var(--page-pad)}
     .gallery-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:28px;letter-spacing:.12em}
     .gallery-sub{color:var(--ink-weak);font-size:14px;letter-spacing:.08em;text-transform:uppercase}
-    .gallery-grid{display:grid;grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));gap:0;margin-inline:calc(-1 * var(--page-pad))}
+    .gallery-grid{display:grid;grid-template-columns:repeat(4, minmax(0, 1fr));gap:0;margin-inline:calc(-1 * var(--page-pad))}
+    @media (max-width:1199px){.gallery-grid{grid-template-columns:repeat(3, minmax(0, 1fr))}}
+    @media (max-width:899px){.gallery-grid{grid-template-columns:repeat(2, minmax(0, 1fr))}}
+    @media (max-width:599px){.gallery-grid{grid-template-columns:minmax(0, 1fr)}}
     .gallery-tile{position:relative;display:grid;place-items:center;transition:filter .18s ease;aspect-ratio:1;background:var(--tile-bg, transparent);overflow:hidden}
     .gallery-tile:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
     .gallery-tile img{width:100%;height:100%;object-fit:contain;vertical-align:middle}


### PR DESCRIPTION
## Summary
- enforce a four-column default for the games gallery layout
- add responsive breakpoints so the grid collapses only when the viewport is too narrow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d938a9bb5883258d35e257ee6e293d