### PR TITLE
Skip index loader when returning from games header

### DIFF
--- a/games/games.html
+++ b/games/games.html
@@ -35,7 +35,7 @@
     .page{min-height:100vh;display:grid;grid-template-rows:auto 1fr auto}
 
     header{padding:32px var(--page-pad) 20px;display:grid;gap:18px;justify-items:center;text-align:center;border-bottom:1px solid var(--line)}
-    .brand-logo{width:120px;height:120px;border-radius:50%;overflow:hidden;display:grid;place-items:center;background:transparent;border:1px solid var(--line)}
+    .brand-logo{width:120px;height:120px;border-radius:50%;overflow:hidden;display:grid;place-items:center;background:transparent}
     .brand-logo img{width:100%;height:100%;object-fit:contain}
     .brand-name{font-family:'Rampart One',system-ui,sans-serif;font-size:32px;letter-spacing:.02em}
     .brand-name img{max-height:78px;object-fit:contain;margin:0 auto}
@@ -75,7 +75,7 @@
 <body>
   <div class="page">
     <header>
-      <a class="brand-logo" href="../index.html" aria-label="トップページへ戻る">
+      <a class="brand-logo" href="../index.html?skipLoading=1#top" aria-label="トップページへ戻る">
         <img src="../image/general/logo.png" alt="Pentas Studio" loading="lazy">
       </a>
       <div class="brand-name">

--- a/index.html
+++ b/index.html
@@ -363,6 +363,24 @@ document.addEventListener('DOMContentLoaded', function(){
     const loading = document.getElementById('loading');
     if(!loading) return;
 
+    const params = new URLSearchParams(window.location.search);
+    const skipLoading = params.has('skipLoading');
+
+    if(skipLoading){
+      loading.classList.add('is-hidden');
+      if(window.history && window.history.replaceState){
+        try{
+          const url = new URL(window.location.href);
+          url.searchParams.delete('skipLoading');
+          const newUrl = url.pathname + url.search + url.hash;
+          window.history.replaceState(null, '', newUrl);
+        }catch(err){
+          // noop
+        }
+      }
+      return;
+    }
+
     const bar  = loading.querySelector('.ps-progress-bar');
     const num  = loading.querySelector('.ps-progress-num');
     const logo = loading.querySelector('.ps-load-logo');


### PR DESCRIPTION
## Summary
- hide the landing loader immediately when the page is opened with the skipLoading query flag and clean up the URL
- update the games page header logo link to pass the skipLoading flag and drop its circular border

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d93cd5585c8325ba4520e8219fadda