### PR TITLE
Fix Seisoin page links

### DIFF
--- a/games/games.html
+++ b/games/games.html
@@ -98,7 +98,7 @@
           <a class="gallery-tile" href="#" aria-label="エスケープゴート" style="--tile-bg:#1f2b2f">
             <img src="../image/games/escape-goat/escape.png" alt="エスケープゴート" loading="lazy">
           </a>
-          <a class="gallery-tile" href="#" aria-label="静葬員" style="--tile-bg:#2f2937">
+          <a class="gallery-tile" href="seisoin/seisoin.html" aria-label="静葬員" style="--tile-bg:#2f2937">
             <img src="../image/games/seisoin/seisoin.png" alt="静葬員" loading="lazy">
           </a>
           <a class="gallery-tile" href="#" aria-label="名刺の管理ができません" style="--tile-bg:#2a2e2b">

--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@ document.addEventListener('DOMContentLoaded', function(){
   const GAMES = [
     {id:'yumeyume',    title:'ゆめゆめ',               img:'image/games/yumeyume/comming.png',   link:'#game-yumeyume'},
     {id:'escapegoat',  title:'エスケープゴート',       img:'image/games/escape-goat/escape.png',    link:'#game-escapegoat'},
-    {id:'seisouin',    title:'静葬員',                 img:'image/games/seisoin/seisoin.png',   link:'#game-seisouin'},
+    {id:'seisouin',    title:'静葬員',                 img:'image/games/seisoin/seisoin.png',   link:'games/seisoin/seisoin.html'},
     {id:'meishi',      title:'名刺の管理ができません', img:'image/games/meishi/meishi.png',    link:'#game-meishi'},
     {id:'informer-rt', title:'インフォーマーリターンズ', img:'image/games/informer/informerR.png', link:'#game-informer-r'},
     {id:'comical',     title:'コミカルミッション',     img:'image/games/comical/comical.png',   link:'#game-comical'},


### PR DESCRIPTION
## Summary
- update the Seisoin entry on the top page to link to the standalone detail page
- point the Seisoin tile on the games listing to its detail page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da275a1b388325b6f256753f96d43d