### PR TITLE
Remove carousel captions and point Escape Goat links to detail page

### DIFF
--- a/games/escape-goat/escape-goat.html
+++ b/games/escape-goat/escape-goat.html
@@ -84,10 +84,16 @@
     .media-block h2{font-size:18px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-weak)}
     .media-video{position:relative;padding-top:56.25%;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#111722}
     .media-video iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
-    .media-gallery{display:grid;gap:14px}
-    .media-gallery figure{margin:0;border-radius:14px;overflow:hidden}
-    .media-gallery img{width:100%;height:100%;object-fit:cover}
-    .media-gallery figcaption{padding:12px 14px;font-size:13px;color:var(--ink-weak);background:rgba(0,0,0,.28)}
+    .media-carousel{display:grid;gap:14px}
+    .media-carousel-viewport{position:relative;overflow:hidden;border-radius:14px}
+    .media-carousel-track{display:flex;transition:transform .4s ease}
+    .media-carousel-item{margin:0;flex:0 0 100%;min-width:100%;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#111722;display:block}
+    .media-carousel-item img{width:100%;height:auto;object-fit:cover}
+    .media-carousel-controls{display:flex;align-items:center;justify-content:space-between;gap:12px}
+    .carousel-button{width:44px;height:44px;border-radius:50%;border:1px solid var(--line);background:rgba(255,255,255,.08);color:var(--ink);display:grid;place-items:center;cursor:pointer;transition:background-color .18s ease,transform .18s ease,color .18s ease,border-color .18s ease}
+    .carousel-button:hover{background:var(--accent);color:var(--bg);border-color:transparent;transform:translateY(-1px)}
+    .carousel-button:disabled{opacity:.38;cursor:not-allowed;background:rgba(255,255,255,.04);color:var(--ink-weak);border-color:var(--line);transform:none}
+    .carousel-status{margin:0;font-size:13px;color:var(--ink-weak);letter-spacing:.08em}
 
     footer{padding:28px var(--page-pad) 38px;border-top:1px solid var(--line);display:grid;gap:12px;justify-items:center}
     .sns{display:flex;gap:12px;justify-content:center}
@@ -177,10 +183,6 @@
                   <p>「元凶を1人決めろ。そいつに”責任”を取らせる。」</p>
                   <p>なぜ遺体が違ったのか？誰のミスによるものか。あるいは誰かの策略か。疑い・裏切り・押し付け合い──命を賭けた泥沼の議論が今、始まる。そして、たどり着くたった一つの真実とは。GM不要！4人プレイのトーク型ミステリーゲーム！</p>
                 </section>
-                <section class="overview-block" aria-labelledby="componentHeading">
-                  <h2 id="componentHeading">コンポーネント</h2>
-                  <p>現在準備中です。公開まで今しばらくお待ちください。</p>
-                </section>
                 <section class="purchase-block" aria-labelledby="purchaseHeading">
                   <h2 id="purchaseHeading">購入はこちら</h2>
                   <div class="purchase-cta">
@@ -191,18 +193,25 @@
               </div>
 
               <div class="overview-media">
-                <section class="media-block" aria-labelledby="videoHeading">
-                  <h2 id="videoHeading">動画</h2>
-                  <p class="cta-note">紹介動画は現在準備中です。</p>
-                </section>
-
                 <section class="media-block" aria-labelledby="galleryHeading">
                   <h2 id="galleryHeading">ギャラリー</h2>
-                  <div class="media-gallery">
-                    <figure>
-                      <img src="../../image/games/escape-goat/escape.png" alt="エスケープゴートのキービジュアル" loading="lazy">
-                      <figcaption>闇に潜む静葬員たちを描いたビジュアル。</figcaption>
-                    </figure>
+                  <div class="media-carousel" data-carousel>
+                    <div class="media-carousel-viewport">
+                      <div class="media-carousel-track" data-carousel-track>
+                        <figure class="media-carousel-item">
+                          <img src="../../image/games/escape-goat/escape.png" alt="エスケープゴートのキービジュアル" loading="lazy">
+                        </figure>
+                      </div>
+                    </div>
+                    <div class="media-carousel-controls">
+                      <button type="button" class="carousel-button" data-carousel-button="prev" aria-label="前の画像" disabled>
+                        <span aria-hidden="true">‹</span>
+                      </button>
+                      <p class="carousel-status" data-carousel-status aria-live="polite">1 / 1</p>
+                      <button type="button" class="carousel-button" data-carousel-button="next" aria-label="次の画像" disabled>
+                        <span aria-hidden="true">›</span>
+                      </button>
+                    </div>
                   </div>
                 </section>
               </div>
@@ -235,5 +244,42 @@
       <p class="footer-copy">© pantas studio All Right Reserved.</p>
     </footer>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('[data-carousel]').forEach((carousel) => {
+        const track = carousel.querySelector('[data-carousel-track]');
+        if (!track) return;
+        const slides = Array.from(track.children);
+        if (!slides.length) return;
+        const prevButton = carousel.querySelector('[data-carousel-button="prev"]');
+        const nextButton = carousel.querySelector('[data-carousel-button="next"]');
+        const status = carousel.querySelector('[data-carousel-status]');
+        let index = 0;
+
+        const update = () => {
+          track.style.transform = `translateX(-${index * 100}%)`;
+          if (prevButton) prevButton.disabled = index === 0;
+          if (nextButton) nextButton.disabled = index === slides.length - 1;
+          if (status) status.textContent = `${index + 1} / ${slides.length}`;
+        };
+
+        prevButton?.addEventListener('click', () => {
+          if (index > 0) {
+            index -= 1;
+            update();
+          }
+        });
+
+        nextButton?.addEventListener('click', () => {
+          if (index < slides.length - 1) {
+            index += 1;
+            update();
+          }
+        });
+
+        update();
+      });
+    });
+  </script>
 </body>
 </html>

--- a/games/games.html
+++ b/games/games.html
@@ -95,7 +95,7 @@
           <a class="gallery-tile" href="#" aria-label="ゆめゆめ" style="--tile-bg:#202b38">
             <img src="../image/games/yumeyume/comming.png" alt="ゆめゆめ" loading="lazy">
           </a>
-          <a class="gallery-tile" href="#" aria-label="エスケープゴート" style="--tile-bg:#1f2b2f">
+          <a class="gallery-tile" href="escape-goat/escape-goat.html" aria-label="エスケープゴート" style="--tile-bg:#1f2b2f">
             <img src="../image/games/escape-goat/escape.png" alt="エスケープゴート" loading="lazy">
           </a>
           <a class="gallery-tile" href="seisoin/seisoin.html" aria-label="静葬員" style="--tile-bg:#2f2937">

--- a/games/seisoin/seisoin.html
+++ b/games/seisoin/seisoin.html
@@ -83,10 +83,16 @@
     .media-block h2{font-size:18px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-weak)}
     .media-video{position:relative;padding-top:56.25%;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#111722}
     .media-video iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
-    .media-gallery{display:grid;gap:14px}
-    .media-gallery figure{margin:0;border-radius:14px;overflow:hidden}
-    .media-gallery img{width:100%;height:100%;object-fit:cover}
-    .media-gallery figcaption{padding:12px 14px;font-size:13px;color:var(--ink-weak);background:rgba(0,0,0,.28)}
+    .media-carousel{display:grid;gap:14px}
+    .media-carousel-viewport{position:relative;overflow:hidden;border-radius:14px}
+    .media-carousel-track{display:flex;transition:transform .4s ease}
+    .media-carousel-item{margin:0;flex:0 0 100%;min-width:100%;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#111722;display:block}
+    .media-carousel-item img{width:100%;height:auto;object-fit:cover}
+    .media-carousel-controls{display:flex;align-items:center;justify-content:space-between;gap:12px}
+    .carousel-button{width:44px;height:44px;border-radius:50%;border:1px solid var(--line);background:rgba(255,255,255,.08);color:var(--ink);display:grid;place-items:center;cursor:pointer;transition:background-color .18s ease,transform .18s ease,color .18s ease,border-color .18s ease}
+    .carousel-button:hover{background:var(--accent);color:var(--bg);border-color:transparent;transform:translateY(-1px)}
+    .carousel-button:disabled{opacity:.38;cursor:not-allowed;background:rgba(255,255,255,.04);color:var(--ink-weak);border-color:var(--line);transform:none}
+    .carousel-status{margin:0;font-size:13px;color:var(--ink-weak);letter-spacing:.08em}
 
     footer{padding:28px var(--page-pad) 38px;border-top:1px solid var(--line);display:grid;gap:12px;justify-items:center}
     .sns{display:flex;gap:12px;justify-content:center}
@@ -206,11 +212,23 @@
 
                 <section class="media-block" aria-labelledby="galleryHeading">
                   <h2 id="galleryHeading">ギャラリー</h2>
-                  <div class="media-gallery">
-                    <figure>
-                      <img src="../../image/games/seisoin/seisoin.png" alt="静葬員のコンポーネント一式" loading="lazy">
-                      <figcaption>活動拠点から車箱まで、静葬員の世界観を詰め込んだ内容物。</figcaption>
-                    </figure>
+                  <div class="media-carousel" data-carousel>
+                    <div class="media-carousel-viewport">
+                      <div class="media-carousel-track" data-carousel-track>
+                        <figure class="media-carousel-item">
+                          <img src="../../image/games/seisoin/seisoin.png" alt="静葬員のコンポーネント一式" loading="lazy">
+                        </figure>
+                      </div>
+                    </div>
+                    <div class="media-carousel-controls">
+                      <button type="button" class="carousel-button" data-carousel-button="prev" aria-label="前の画像" disabled>
+                        <span aria-hidden="true">‹</span>
+                      </button>
+                      <p class="carousel-status" data-carousel-status aria-live="polite">1 / 1</p>
+                      <button type="button" class="carousel-button" data-carousel-button="next" aria-label="次の画像" disabled>
+                        <span aria-hidden="true">›</span>
+                      </button>
+                    </div>
                   </div>
                 </section>
               </div>
@@ -243,5 +261,42 @@
       <p class="footer-copy">© pantas studio All Right Reserved.</p>
     </footer>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('[data-carousel]').forEach((carousel) => {
+        const track = carousel.querySelector('[data-carousel-track]');
+        if (!track) return;
+        const slides = Array.from(track.children);
+        if (!slides.length) return;
+        const prevButton = carousel.querySelector('[data-carousel-button="prev"]');
+        const nextButton = carousel.querySelector('[data-carousel-button="next"]');
+        const status = carousel.querySelector('[data-carousel-status]');
+        let index = 0;
+
+        const update = () => {
+          track.style.transform = `translateX(-${index * 100}%)`;
+          if (prevButton) prevButton.disabled = index === 0;
+          if (nextButton) nextButton.disabled = index === slides.length - 1;
+          if (status) status.textContent = `${index + 1} / ${slides.length}`;
+        };
+
+        prevButton?.addEventListener('click', () => {
+          if (index > 0) {
+            index -= 1;
+            update();
+          }
+        });
+
+        nextButton?.addEventListener('click', () => {
+          if (index < slides.length - 1) {
+            index += 1;
+            update();
+          }
+        });
+
+        update();
+      });
+    });
+  </script>
 </body>
 </html>

--- a/games/template/template.html
+++ b/games/template/template.html
@@ -83,10 +83,16 @@
     .media-block h2{font-size:18px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-weak)}
     .media-video{position:relative;padding-top:56.25%;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#111722}
     .media-video iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
-    .media-gallery{display:grid;gap:14px}
-    .media-gallery figure{margin:0;border-radius:14px;overflow:hidden}
-    .media-gallery img{width:100%;height:100%;object-fit:cover}
-    .media-gallery figcaption{padding:12px 14px;font-size:13px;color:var(--ink-weak);background:rgba(0,0,0,.28)}
+    .media-carousel{display:grid;gap:14px}
+    .media-carousel-viewport{position:relative;overflow:hidden;border-radius:14px}
+    .media-carousel-track{display:flex;transition:transform .4s ease}
+    .media-carousel-item{margin:0;flex:0 0 100%;min-width:100%;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#111722;display:block}
+    .media-carousel-item img{width:100%;height:auto;object-fit:cover}
+    .media-carousel-controls{display:flex;align-items:center;justify-content:space-between;gap:12px}
+    .carousel-button{width:44px;height:44px;border-radius:50%;border:1px solid var(--line);background:rgba(255,255,255,.08);color:var(--ink);display:grid;place-items:center;cursor:pointer;transition:background-color .18s ease,transform .18s ease,color .18s ease,border-color .18s ease}
+    .carousel-button:hover{background:var(--accent);color:var(--bg);border-color:transparent;transform:translateY(-1px)}
+    .carousel-button:disabled{opacity:.38;cursor:not-allowed;background:rgba(255,255,255,.04);color:var(--ink-weak);border-color:var(--line);transform:none}
+    .carousel-status{margin:0;font-size:13px;color:var(--ink-weak);letter-spacing:.08em}
 
     footer{padding:28px var(--page-pad) 38px;border-top:1px solid var(--line);display:grid;gap:12px;justify-items:center}
     .sns{display:flex;gap:12px;justify-content:center}
@@ -201,19 +207,29 @@
 
                 <section class="media-block" aria-labelledby="galleryHeading">
                   <h2 id="galleryHeading">ギャラリー</h2>
-                  <div class="media-gallery">
-                    <figure>
-                      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 600'%3E%3Crect width='800' height='600' fill='%23111722'/%3E%3Cpath d='M0 520h800v80H0z' fill='%23000' opacity='.24'/%3E%3Ctext x='50%' y='50%' fill='%23aeb8c4' font-family='sans-serif' font-size='36' text-anchor='middle'%3EPhoto Placeholder%3C/text%3E%3C/svg%3E" alt="ギャラリー画像1の説明" loading="lazy">
-                      <figcaption>ギャラリーの説明を入力してください。</figcaption>
-                    </figure>
-                    <figure>
-                      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 600'%3E%3Crect width='800' height='600' fill='%23111722'/%3E%3Cpath d='M0 520h800v80H0z' fill='%23000' opacity='.24'/%3E%3Ctext x='50%' y='50%' fill='%23aeb8c4' font-family='sans-serif' font-size='36' text-anchor='middle'%3EPhoto Placeholder%3C/text%3E%3C/svg%3E" alt="ギャラリー画像2の説明" loading="lazy">
-                      <figcaption>ギャラリーの説明を入力してください。</figcaption>
-                    </figure>
-                    <figure>
-                      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 600'%3E%3Crect width='800' height='600' fill='%23111722'/%3E%3Cpath d='M0 520h800v80H0z' fill='%23000' opacity='.24'/%3E%3Ctext x='50%' y='50%' fill='%23aeb8c4' font-family='sans-serif' font-size='36' text-anchor='middle'%3EPhoto Placeholder%3C/text%3E%3C/svg%3E" alt="ギャラリー画像3の説明" loading="lazy">
-                      <figcaption>ギャラリーの説明を入力してください。</figcaption>
-                    </figure>
+                  <div class="media-carousel" data-carousel>
+                    <div class="media-carousel-viewport">
+                      <div class="media-carousel-track" data-carousel-track>
+                        <figure class="media-carousel-item">
+                          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 600'%3E%3Crect width='800' height='600' fill='%23111722'/%3E%3Cpath d='M0 520h800v80H0z' fill='%23000' opacity='.24'/%3E%3Ctext x='50%' y='50%' fill='%23aeb8c4' font-family='sans-serif' font-size='36' text-anchor='middle'%3EPhoto Placeholder%3C/text%3E%3C/svg%3E" alt="ギャラリー画像1の説明" loading="lazy">
+                        </figure>
+                        <figure class="media-carousel-item">
+                          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 600'%3E%3Crect width='800' height='600' fill='%23111722'/%3E%3Cpath d='M0 520h800v80H0z' fill='%23000' opacity='.24'/%3E%3Ctext x='50%' y='50%' fill='%23aeb8c4' font-family='sans-serif' font-size='36' text-anchor='middle'%3EPhoto Placeholder%3C/text%3E%3C/svg%3E" alt="ギャラリー画像2の説明" loading="lazy">
+                        </figure>
+                        <figure class="media-carousel-item">
+                          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 600'%3E%3Crect width='800' height='600' fill='%23111722'/%3E%3Cpath d='M0 520h800v80H0z' fill='%23000' opacity='.24'/%3E%3Ctext x='50%' y='50%' fill='%23aeb8c4' font-family='sans-serif' font-size='36' text-anchor='middle'%3EPhoto Placeholder%3C/text%3E%3C/svg%3E" alt="ギャラリー画像3の説明" loading="lazy">
+                        </figure>
+                      </div>
+                    </div>
+                    <div class="media-carousel-controls">
+                      <button type="button" class="carousel-button" data-carousel-button="prev" aria-label="前の画像" disabled>
+                        <span aria-hidden="true">‹</span>
+                      </button>
+                      <p class="carousel-status" data-carousel-status aria-live="polite">1 / 3</p>
+                      <button type="button" class="carousel-button" data-carousel-button="next" aria-label="次の画像">
+                        <span aria-hidden="true">›</span>
+                      </button>
+                    </div>
                   </div>
                 </section>
               </div>
@@ -246,5 +262,42 @@
       <p class="footer-copy">© pantas studio All Right Reserved.</p>
     </footer>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('[data-carousel]').forEach((carousel) => {
+        const track = carousel.querySelector('[data-carousel-track]');
+        if (!track) return;
+        const slides = Array.from(track.children);
+        if (!slides.length) return;
+        const prevButton = carousel.querySelector('[data-carousel-button="prev"]');
+        const nextButton = carousel.querySelector('[data-carousel-button="next"]');
+        const status = carousel.querySelector('[data-carousel-status]');
+        let index = 0;
+
+        const update = () => {
+          track.style.transform = `translateX(-${index * 100}%)`;
+          if (prevButton) prevButton.disabled = index === 0;
+          if (nextButton) nextButton.disabled = index === slides.length - 1;
+          if (status) status.textContent = `${index + 1} / ${slides.length}`;
+        };
+
+        prevButton?.addEventListener('click', () => {
+          if (index > 0) {
+            index -= 1;
+            update();
+          }
+        });
+
+        nextButton?.addEventListener('click', () => {
+          if (index < slides.length - 1) {
+            index += 1;
+            update();
+          }
+        });
+
+        update();
+      });
+    });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@ document.addEventListener('DOMContentLoaded', function(){
   // ===== Data =====
   const GAMES = [
     {id:'yumeyume',    title:'ゆめゆめ',               img:'image/games/yumeyume/comming.png',   link:'#game-yumeyume'},
-    {id:'escapegoat',  title:'エスケープゴート',       img:'image/games/escape-goat/escape.png',    link:'#game-escapegoat'},
+    {id:'escapegoat',  title:'エスケープゴート',       img:'image/games/escape-goat/escape.png',    link:'games/escape-goat/escape-goat.html'},
     {id:'seisouin',    title:'静葬員',                 img:'image/games/seisoin/seisoin.png',   link:'games/seisoin/seisoin.html'},
     {id:'meishi',      title:'名刺の管理ができません', img:'image/games/meishi/meishi.png',    link:'#game-meishi'},
     {id:'informer-rt', title:'インフォーマーリターンズ', img:'image/games/informer/informerR.png', link:'#game-informer-r'},


### PR DESCRIPTION
## Summary
- replace the static gallery layout with a manual carousel component across game detail pages
- remove the unused video and component sections from the Escape Goat page
- add shared carousel styles and scripting to support button-driven navigation without auto-play
- remove carousel captions from game detail galleries to match the requested design
- update the Escape Goat links on the home and games listing pages to point to the dedicated detail page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da32f4ea488325a52e56e390539400