### PR TITLE
Tighten hero heading spacing and reorder purchase details

### DIFF
--- a/games/escape-goat/escape-goat.html
+++ b/games/escape-goat/escape-goat.html
@@ -54,12 +54,15 @@
     .game-hero{display:grid;grid-template-columns:1.1fr 1fr;gap:36px;align-items:center}
     .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:320px;display:grid;place-items:center;padding:0}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
-    .hero-info{display:grid;gap:22px}
+    .hero-info{display:grid;gap:18px}
+    .hero-heading{display:grid;gap:4px}
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em}
-    .game-meta{display:flex;flex-wrap:wrap;gap:14px;padding:16px;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid var(--line)}
-    .game-meta dt{font-size:12px;letter-spacing:.12em;color:var(--ink-weak)}
-    .game-meta dd{margin:4px 0 0;font-size:18px;font-weight:700;letter-spacing:.06em}
+    .game-meta{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0;padding:0;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid var(--line);overflow:hidden}
+    .game-meta>div{position:relative;padding:18px 16px;display:grid;gap:6px;justify-items:center}
+    .game-meta>div:not(:last-child)::after{content:"";position:absolute;top:18px;bottom:18px;right:0;width:1px;background:var(--line)}
+    .game-meta dt{font-size:12px;letter-spacing:.12em;color:var(--ink-weak);text-align:center}
+    .game-meta dd{margin:0;font-size:18px;font-weight:700;letter-spacing:.06em;text-align:center}
     .hero-lead{font-size:16px;line-height:1.8;color:#dde3ec}
 
     .game-overview{display:grid;grid-template-columns:1fr 0.92fr;gap:36px;align-items:start}
@@ -70,13 +73,13 @@
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 
-    .purchase-block{display:grid;gap:14px;padding:0}
+    .purchase-block{display:grid;gap:12px;padding:0}
     .purchase-block h2{font-size:20px;letter-spacing:.08em;color:var(--accent)}
-    .purchase-block p{font-size:15px;line-height:1.9;color:#f0f4fa}
-    .purchase-cta{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+    .purchase-cta{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .cta-note{font-size:13px;color:var(--ink-weak)}
+    .purchase-price{font-size:18px;font-weight:700;letter-spacing:.06em;display:inline-flex;align-items:center;line-height:1.4}
+    .purchase-note{font-size:13px;color:var(--ink-weak)}
     .cta-button.is-disabled{background:#707680;color:var(--ink);opacity:.6;box-shadow:none;pointer-events:none}
 
     .overview-media{display:grid;gap:24px}
@@ -120,7 +123,10 @@
       .section-band{padding:36px var(--page-pad)}
       .brand-name{font-size:28px}
       main{padding-bottom:60px}
-      .game-meta{flex-direction:column;align-items:flex-start;padding:18px}
+      .game-meta{grid-template-columns:1fr}
+      .game-meta>div{justify-items:start;align-items:start;padding:16px 18px}
+      .game-meta>div:not(:last-child)::after{top:auto;bottom:0;left:18px;right:18px;width:auto;height:1px}
+      .game-meta dt,.game-meta dd{text-align:left}
       .purchase-block{gap:14px}
     }
   </style>
@@ -145,8 +151,10 @@
                 <img src="../../image/games/escape-goat/escape.png" alt="エスケープゴートのキービジュアル" loading="lazy">
               </div>
               <div class="hero-info">
-                <p class="game-category">マーダーミステリー</p>
-                <h1 id="gameTitle" class="game-title">エスケープゴート</h1>
+                <div class="hero-heading">
+                  <p class="game-category">マーダーミステリー</p>
+                  <h1 id="gameTitle" class="game-title">エスケープゴート</h1>
+                </div>
                 <dl class="game-meta">
                   <div>
                     <dt>プレイ人数</dt>
@@ -162,6 +170,14 @@
                   </div>
                 </dl>
                 <p class="hero-lead">処理した遺体が別人だった…。<br>「静葬員」の世界で遊ぶ4人用トーク型ミステリー</p>
+                <section class="purchase-block" aria-labelledby="purchaseHeading">
+                  <h2 id="purchaseHeading">購入はこちら</h2>
+                  <div class="purchase-cta">
+                    <span class="purchase-price">￥2,000（税込）</span>
+                    <span class="cta-button is-disabled" aria-disabled="true">準備中</span>
+                  </div>
+                  <p class="purchase-note">※ 販売ページの公開までしばらくお待ちください。</p>
+                </section>
               </div>
             </div>
           </div>
@@ -182,13 +198,6 @@
                   <p>アジトに戻るや否や発覚した、あってはならない重大なミス。ボスが4人へ静かに告げる。</p>
                   <p>「元凶を1人決めろ。そいつに”責任”を取らせる。」</p>
                   <p>なぜ遺体が違ったのか？誰のミスによるものか。あるいは誰かの策略か。疑い・裏切り・押し付け合い──命を賭けた泥沼の議論が今、始まる。そして、たどり着くたった一つの真実とは。GM不要！4人プレイのトーク型ミステリーゲーム！</p>
-                </section>
-                <section class="purchase-block" aria-labelledby="purchaseHeading">
-                  <h2 id="purchaseHeading">購入はこちら</h2>
-                  <div class="purchase-cta">
-                    <span class="cta-button is-disabled" aria-disabled="true">準備中</span>
-                    <p class="cta-note">※ 販売ページの公開までしばらくお待ちください。</p>
-                  </div>
                 </section>
               </div>
 

--- a/games/seisoin/seisoin.html
+++ b/games/seisoin/seisoin.html
@@ -54,12 +54,15 @@
     .game-hero{display:grid;grid-template-columns:1.1fr 1fr;gap:36px;align-items:center}
     .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:320px;display:grid;place-items:center;padding:0}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
-    .hero-info{display:grid;gap:22px}
+    .hero-info{display:grid;gap:18px}
+    .hero-heading{display:grid;gap:4px}
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em}
-    .game-meta{display:flex;flex-wrap:wrap;gap:14px;padding:16px;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid var(--line)}
-    .game-meta dt{font-size:12px;letter-spacing:.12em;color:var(--ink-weak)}
-    .game-meta dd{margin:4px 0 0;font-size:18px;font-weight:700;letter-spacing:.06em}
+    .game-meta{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0;padding:0;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid var(--line);overflow:hidden}
+    .game-meta>div{position:relative;padding:18px 16px;display:grid;gap:6px;justify-items:center}
+    .game-meta>div:not(:last-child)::after{content:"";position:absolute;top:18px;bottom:18px;right:0;width:1px;background:var(--line)}
+    .game-meta dt{font-size:12px;letter-spacing:.12em;color:var(--ink-weak);text-align:center}
+    .game-meta dd{margin:0;font-size:18px;font-weight:700;letter-spacing:.06em;text-align:center}
     .hero-lead{font-size:16px;line-height:1.8;color:#dde3ec}
 
     .game-overview{display:grid;grid-template-columns:1fr 0.92fr;gap:36px;align-items:start}
@@ -70,13 +73,13 @@
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 
-    .purchase-block{display:grid;gap:14px;padding:0}
+    .purchase-block{display:grid;gap:12px;padding:0}
     .purchase-block h2{font-size:20px;letter-spacing:.08em;color:var(--accent)}
-    .purchase-block p{font-size:15px;line-height:1.9;color:#f0f4fa}
-    .purchase-cta{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+    .purchase-cta{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .cta-note{font-size:13px;color:var(--ink-weak)}
+    .purchase-price{font-size:18px;font-weight:700;letter-spacing:.06em;display:inline-flex;align-items:center;line-height:1.4}
+    .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}
     .media-block{display:grid;gap:16px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
@@ -119,7 +122,10 @@
       .section-band{padding:36px var(--page-pad)}
       .brand-name{font-size:28px}
       main{padding-bottom:60px}
-      .game-meta{flex-direction:column;align-items:flex-start;padding:18px}
+      .game-meta{grid-template-columns:1fr}
+      .game-meta>div{justify-items:start;align-items:start;padding:16px 18px}
+      .game-meta>div:not(:last-child)::after{top:auto;bottom:0;left:18px;right:18px;width:auto;height:1px}
+      .game-meta dt,.game-meta dd{text-align:left}
       .purchase-block{gap:14px}
     }
   </style>
@@ -144,8 +150,10 @@
                 <img src="../../image/games/seisoin/seisoin.png" alt="静葬員のキービジュアル" loading="lazy">
               </div>
               <div class="hero-info">
-                <p class="game-category">ボードゲーム / アクション</p>
-                <h1 id="gameTitle" class="game-title">静葬員</h1>
+                <div class="hero-heading">
+                  <p class="game-category">ボードゲーム / アクション</p>
+                  <h1 id="gameTitle" class="game-title">静葬員</h1>
+                </div>
                 <dl class="game-meta">
                   <div>
                     <dt>プレイ人数</dt>
@@ -161,6 +169,14 @@
                   </div>
                 </dl>
                 <p class="hero-lead">―静かに、葬れ―<br>車ボックスと遺体コマを使って遊ぶミープル運搬バランスアクションゲーム</p>
+                <section class="purchase-block" aria-labelledby="purchaseHeading">
+                  <h2 id="purchaseHeading">購入はこちら</h2>
+                  <div class="purchase-cta">
+                    <span class="purchase-price">￥3,500（税込）</span>
+                    <a class="cta-button" href="https://bodoge.hoobby.net/games/seisoin" target="_blank" rel="noopener noreferrer">ボドゲーマで購入</a>
+                  </div>
+                  <p class="purchase-note">※ 外部サイト「ボドゲーマ」の商品ページに移動します。</p>
+                </section>
               </div>
             </div>
           </div>
@@ -193,23 +209,9 @@
                     <li>遺体処理場ボード</li>
                   </ul>
                 </section>
-                <section class="purchase-block" aria-labelledby="purchaseHeading">
-                  <h2 id="purchaseHeading">購入はこちら</h2>
-                  <div class="purchase-cta">
-                    <a class="cta-button" href="https://bodoge.hoobby.net/games/seisoin" target="_blank" rel="noopener noreferrer">ボドゲーマで購入</a>
-                    <p class="cta-note">※ 外部サイト「ボドゲーマ」の商品ページに移動します。</p>
-                  </div>
-                </section>
               </div>
 
               <div class="overview-media">
-                <section class="media-block" aria-labelledby="videoHeading">
-                  <h2 id="videoHeading">動画</h2>
-                  <div class="media-video">
-                    <iframe src="https://www.youtube.com/embed/pI0k9d1G-GI" title="静葬員 紹介動画" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-                  </div>
-                </section>
-
                 <section class="media-block" aria-labelledby="galleryHeading">
                   <h2 id="galleryHeading">ギャラリー</h2>
                   <div class="media-carousel" data-carousel>
@@ -229,6 +231,13 @@
                         <span aria-hidden="true">›</span>
                       </button>
                     </div>
+                  </div>
+                </section>
+
+                <section class="media-block" aria-labelledby="videoHeading">
+                  <h2 id="videoHeading">動画</h2>
+                  <div class="media-video">
+                    <iframe src="https://www.youtube.com/embed/pI0k9d1G-GI" title="静葬員 紹介動画" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                   </div>
                 </section>
               </div>

--- a/games/template/template.html
+++ b/games/template/template.html
@@ -54,12 +54,15 @@
     .game-hero{display:grid;grid-template-columns:1.1fr 1fr;gap:36px;align-items:center}
     .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:320px;display:grid;place-items:center;padding:0}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
-    .hero-info{display:grid;gap:22px}
+    .hero-info{display:grid;gap:18px}
+    .hero-heading{display:grid;gap:4px}
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em}
-    .game-meta{display:flex;flex-wrap:wrap;gap:14px;padding:16px;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid var(--line)}
-    .game-meta dt{font-size:12px;letter-spacing:.12em;color:var(--ink-weak)}
-    .game-meta dd{margin:4px 0 0;font-size:18px;font-weight:700;letter-spacing:.06em}
+    .game-meta{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0;padding:0;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid var(--line);overflow:hidden}
+    .game-meta>div{position:relative;padding:18px 16px;display:grid;gap:6px;justify-items:center}
+    .game-meta>div:not(:last-child)::after{content:"";position:absolute;top:18px;bottom:18px;right:0;width:1px;background:var(--line)}
+    .game-meta dt{font-size:12px;letter-spacing:.12em;color:var(--ink-weak);text-align:center}
+    .game-meta dd{margin:0;font-size:18px;font-weight:700;letter-spacing:.06em;text-align:center}
     .hero-lead{font-size:16px;line-height:1.8;color:#dde3ec}
 
     .game-overview{display:grid;grid-template-columns:1fr 0.92fr;gap:36px;align-items:start}
@@ -70,13 +73,13 @@
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 
-    .purchase-block{display:grid;gap:14px;padding:0}
+    .purchase-block{display:grid;gap:12px;padding:0}
     .purchase-block h2{font-size:20px;letter-spacing:.08em;color:var(--accent)}
-    .purchase-block p{font-size:15px;line-height:1.9;color:#f0f4fa}
-    .purchase-cta{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+    .purchase-cta{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .cta-note{font-size:13px;color:var(--ink-weak)}
+    .purchase-price{font-size:18px;font-weight:700;letter-spacing:.06em;display:inline-flex;align-items:center;line-height:1.4}
+    .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}
     .media-block{display:grid;gap:16px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
@@ -119,7 +122,10 @@
       .section-band{padding:36px var(--page-pad)}
       .brand-name{font-size:28px}
       main{padding-bottom:60px}
-      .game-meta{flex-direction:column;align-items:flex-start;padding:18px}
+      .game-meta{grid-template-columns:1fr}
+      .game-meta>div{justify-items:start;align-items:start;padding:16px 18px}
+      .game-meta>div:not(:last-child)::after{top:auto;bottom:0;left:18px;right:18px;width:auto;height:1px}
+      .game-meta dt,.game-meta dd{text-align:left}
       .purchase-block{gap:14px}
     }
   </style>
@@ -144,8 +150,10 @@
                 <div class="media-fallback">ゲームのキービジュアルを配置してください<br>（例：4000×3000px 推奨）</div>
               </div>
               <div class="hero-info">
-                <p class="game-category">Game Category</p>
-                <h1 id="gameTitle" class="game-title">ゲームタイトル</h1>
+                <div class="hero-heading">
+                  <p class="game-category">Game Category</p>
+                  <h1 id="gameTitle" class="game-title">ゲームタイトル</h1>
+                </div>
                 <dl class="game-meta">
                   <div>
                     <dt>プレイ人数</dt>
@@ -161,6 +169,14 @@
                   </div>
                 </dl>
                 <p class="hero-lead">ここにゲームのリードテキストを記載します。作品の世界観や魅力が一目で伝わるキャッチコピーや概要を記入してください。</p>
+                <section class="purchase-block" aria-labelledby="purchaseHeading">
+                  <h2 id="purchaseHeading">購入はこちら</h2>
+                  <div class="purchase-cta">
+                    <span class="purchase-price">￥3,000（税込）</span>
+                    <a class="cta-button" href="https://example.com" target="_blank" rel="noopener noreferrer">購入ページへ</a>
+                  </div>
+                  <p class="purchase-note">※ リンク先URLとボタン文言を適宜差し替えてください。</p>
+                </section>
               </div>
             </div>
           </div>
@@ -187,24 +203,9 @@
                   </ul>
                   <p class="component-note">※ 実際の内容物に合わせて編集してください。</p>
                 </section>
-                <section class="purchase-block" aria-labelledby="purchaseHeading">
-                  <h2 id="purchaseHeading">購入はこちら</h2>
-                  <div class="purchase-cta">
-                    <a class="cta-button" href="https://example.com" target="_blank" rel="noopener noreferrer">購入ページへ</a>
-                    <p class="cta-note">※ リンク先URLとボタン文言を適宜差し替えてください。</p>
-                  </div>
-                </section>
               </div>
 
               <div class="overview-media">
-                <section class="media-block" aria-labelledby="videoHeading">
-                  <h2 id="videoHeading">動画</h2>
-                  <div class="media-video">
-                    <iframe src="https://www.youtube.com/embed/VIDEO_ID" title="ゲーム紹介動画" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-                  </div>
-                  <p style="font-size:13px;color:var(--ink-weak);">※ YouTube動画のIDを差し替えてご利用ください。</p>
-                </section>
-
                 <section class="media-block" aria-labelledby="galleryHeading">
                   <h2 id="galleryHeading">ギャラリー</h2>
                   <div class="media-carousel" data-carousel>
@@ -231,6 +232,14 @@
                       </button>
                     </div>
                   </div>
+                </section>
+
+                <section class="media-block" aria-labelledby="videoHeading">
+                  <h2 id="videoHeading">動画</h2>
+                  <div class="media-video">
+                    <iframe src="https://www.youtube.com/embed/VIDEO_ID" title="ゲーム紹介動画" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                  </div>
+                  <p style="font-size:13px;color:var(--ink-weak);">※ YouTube動画のIDを差し替えてご利用ください。</p>
                 </section>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated hero heading wrapper to shrink the gap between categories and titles across the template and game pages
- display purchase prices before the CTA and swap to yen-prefixed amounts, updating Escape Goat and 静葬員 pricing

## Testing
- Not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68e20196e3cc8325988902638a86627e