### PR TITLE
Keep purchase price and button aligned

### DIFF
--- a/games/escape-goat/escape-goat.html
+++ b/games/escape-goat/escape-goat.html
@@ -51,8 +51,8 @@
     .game-hero-band{--section-bg:var(--hero-bg);border-bottom:1px solid var(--line)}
     .game-overview-band{--section-bg:var(--content-bg)}
 
-    .game-hero{display:grid;grid-template-columns:1.1fr 1fr;gap:36px;align-items:center}
-    .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:320px;display:grid;place-items:center;padding:0}
+    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:center}
+    .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:384px;display:grid;place-items:center;padding:0}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
     .hero-info{display:grid;gap:18px}
     .hero-heading{display:grid;gap:4px}
@@ -73,12 +73,14 @@
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 
-    .purchase-block{display:grid;gap:12px;padding:0}
-    .purchase-block h2{font-size:20px;letter-spacing:.08em;color:var(--accent)}
-    .purchase-cta{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
-    .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease}
+    .purchase-block{display:grid;gap:16px;padding:0}
+    .purchase-block::before,
+    .purchase-block::after{content:"";display:block;height:1px;background:rgba(255,255,255,.32)}
+    .purchase-cta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;align-items:center;justify-items:center;width:100%}
+    .purchase-cta>*{width:100%;text-align:center}
+    .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:18px;font-weight:700;letter-spacing:.06em;display:inline-flex;align-items:center;line-height:1.4}
+    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
     .cta-button.is-disabled{background:#707680;color:var(--ink);opacity:.6;box-shadow:none;pointer-events:none}
 
@@ -111,7 +113,7 @@
       :root{--page-pad:20px}
       .section-band{padding:44px var(--page-pad)}
       .game-hero{grid-template-columns:1fr;gap:28px}
-      .hero-media{order:-1;min-height:280px}
+      .hero-media{order:-1;min-height:336px}
       .game-title{font-size:34px}
     }
     @media (max-width:799px){
@@ -127,7 +129,7 @@
       .game-meta>div{justify-items:start;align-items:start;padding:16px 18px}
       .game-meta>div:not(:last-child)::after{top:auto;bottom:0;left:18px;right:18px;width:auto;height:1px}
       .game-meta dt,.game-meta dd{text-align:left}
-      .purchase-block{gap:14px}
+      .purchase-block{gap:10px}
     }
   </style>
 </head>
@@ -170,8 +172,7 @@
                   </div>
                 </dl>
                 <p class="hero-lead">処理した遺体が別人だった…。<br>「静葬員」の世界で遊ぶ4人用トーク型ミステリー</p>
-                <section class="purchase-block" aria-labelledby="purchaseHeading">
-                  <h2 id="purchaseHeading">購入はこちら</h2>
+                <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
                     <span class="purchase-price">￥2,000（税込）</span>
                     <span class="cta-button is-disabled" aria-disabled="true">準備中</span>

--- a/games/seisoin/seisoin.html
+++ b/games/seisoin/seisoin.html
@@ -51,8 +51,8 @@
     .game-hero-band{--section-bg:var(--hero-bg);border-bottom:1px solid var(--line)}
     .game-overview-band{--section-bg:var(--content-bg)}
 
-    .game-hero{display:grid;grid-template-columns:1.1fr 1fr;gap:36px;align-items:center}
-    .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:320px;display:grid;place-items:center;padding:0}
+    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:center}
+    .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:384px;display:grid;place-items:center;padding:0}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
     .hero-info{display:grid;gap:18px}
     .hero-heading{display:grid;gap:4px}
@@ -73,12 +73,14 @@
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 
-    .purchase-block{display:grid;gap:12px;padding:0}
-    .purchase-block h2{font-size:20px;letter-spacing:.08em;color:var(--accent)}
-    .purchase-cta{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
-    .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease}
+    .purchase-block{display:grid;gap:16px;padding:0}
+    .purchase-block::before,
+    .purchase-block::after{content:"";display:block;height:1px;background:rgba(255,255,255,.32)}
+    .purchase-cta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;align-items:center;justify-items:center;width:100%}
+    .purchase-cta>*{width:100%;text-align:center}
+    .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:18px;font-weight:700;letter-spacing:.06em;display:inline-flex;align-items:center;line-height:1.4}
+    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}
@@ -110,7 +112,7 @@
       :root{--page-pad:20px}
       .section-band{padding:44px var(--page-pad)}
       .game-hero{grid-template-columns:1fr;gap:28px}
-      .hero-media{order:-1;min-height:280px}
+      .hero-media{order:-1;min-height:336px}
       .game-title{font-size:34px}
     }
     @media (max-width:799px){
@@ -126,7 +128,7 @@
       .game-meta>div{justify-items:start;align-items:start;padding:16px 18px}
       .game-meta>div:not(:last-child)::after{top:auto;bottom:0;left:18px;right:18px;width:auto;height:1px}
       .game-meta dt,.game-meta dd{text-align:left}
-      .purchase-block{gap:14px}
+      .purchase-block{gap:10px}
     }
   </style>
 </head>
@@ -169,8 +171,7 @@
                   </div>
                 </dl>
                 <p class="hero-lead">―静かに、葬れ―<br>車ボックスと遺体コマを使って遊ぶミープル運搬バランスアクションゲーム</p>
-                <section class="purchase-block" aria-labelledby="purchaseHeading">
-                  <h2 id="purchaseHeading">購入はこちら</h2>
+                <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
                     <span class="purchase-price">￥3,500（税込）</span>
                     <a class="cta-button" href="https://bodoge.hoobby.net/games/seisoin" target="_blank" rel="noopener noreferrer">ボドゲーマで購入</a>

--- a/games/template/template.html
+++ b/games/template/template.html
@@ -51,8 +51,8 @@
     .game-hero-band{--section-bg:var(--hero-bg);border-bottom:1px solid var(--line)}
     .game-overview-band{--section-bg:var(--content-bg)}
 
-    .game-hero{display:grid;grid-template-columns:1.1fr 1fr;gap:36px;align-items:center}
-    .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:320px;display:grid;place-items:center;padding:0}
+    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:center}
+    .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:384px;display:grid;place-items:center;padding:0}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
     .hero-info{display:grid;gap:18px}
     .hero-heading{display:grid;gap:4px}
@@ -73,12 +73,14 @@
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 
-    .purchase-block{display:grid;gap:12px;padding:0}
-    .purchase-block h2{font-size:20px;letter-spacing:.08em;color:var(--accent)}
-    .purchase-cta{display:flex;flex-wrap:wrap;gap:18px;align-items:center}
-    .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease}
+    .purchase-block{display:grid;gap:16px;padding:0}
+    .purchase-block::before,
+    .purchase-block::after{content:"";display:block;height:1px;background:rgba(255,255,255,.32)}
+    .purchase-cta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;align-items:center;justify-items:center;width:100%}
+    .purchase-cta>*{width:100%;text-align:center}
+    .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:999px;background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:18px;font-weight:700;letter-spacing:.06em;display:inline-flex;align-items:center;line-height:1.4}
+    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}
@@ -110,7 +112,7 @@
       :root{--page-pad:20px}
       .section-band{padding:44px var(--page-pad)}
       .game-hero{grid-template-columns:1fr;gap:28px}
-      .hero-media{order:-1;min-height:280px}
+      .hero-media{order:-1;min-height:336px}
       .game-title{font-size:34px}
     }
     @media (max-width:799px){
@@ -126,7 +128,7 @@
       .game-meta>div{justify-items:start;align-items:start;padding:16px 18px}
       .game-meta>div:not(:last-child)::after{top:auto;bottom:0;left:18px;right:18px;width:auto;height:1px}
       .game-meta dt,.game-meta dd{text-align:left}
-      .purchase-block{gap:14px}
+      .purchase-block{gap:10px}
     }
   </style>
 </head>
@@ -169,8 +171,7 @@
                   </div>
                 </dl>
                 <p class="hero-lead">ここにゲームのリードテキストを記載します。作品の世界観や魅力が一目で伝わるキャッチコピーや概要を記入してください。</p>
-                <section class="purchase-block" aria-labelledby="purchaseHeading">
-                  <h2 id="purchaseHeading">購入はこちら</h2>
+                <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
                     <span class="purchase-price">￥3,000（税込）</span>
                     <a class="cta-button" href="https://example.com" target="_blank" rel="noopener noreferrer">購入ページへ</a>


### PR DESCRIPTION
## Summary
- adjust the purchase call-to-action layout to use a two-column grid so the price and button stay aligned on one row across the template and live pages
- remove the "購入はこちら" heading, add visual divider lines, and enlarge the price typography for the purchase area across the template and live pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e212c6599083258182d32bf772a887