### PR TITLE
Tweak hero heading spacing

### DIFF
--- a/games/escape-goat/escape-goat.html
+++ b/games/escape-goat/escape-goat.html
@@ -52,12 +52,12 @@
     .game-hero-band{--section-bg:var(--hero-bg);border-bottom:1px solid var(--line)}
     .game-overview-band{--section-bg:var(--content-bg)}
 
-    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:center}
+    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:start}
     .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:384px;display:grid;place-items:center;padding:0}
     .hero-media img{width:120%;max-width:none;height:auto}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
     .hero-info{display:grid;gap:12px}
-    .hero-heading{display:grid;gap:2px}
+    .hero-heading{display:grid;gap:2px;margin-bottom:4px}
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
 
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em;display:grid;place-items:center;text-align:center;line-height:1.1}
@@ -158,10 +158,10 @@
               </div>
               <div class="hero-info">
                 <div class="hero-heading">
-                  <p class="game-category">マーダーミステリー</p>
                   <h1 id="gameTitle" class="game-title">
                     <img src="../../image/games/escape-goat/game-logo.png" alt="エスケープゴート" loading="lazy">
                   </h1>
+                  <p class="game-category">マーダーミステリー</p>
                 </div>
                 <p class="hero-lead">処理した遺体が別人だった…。<br>「静葬員」の世界で遊ぶ4人用トーク型ミステリー</p>
                 <dl class="game-meta">

--- a/games/seisoin/seisoin.html
+++ b/games/seisoin/seisoin.html
@@ -52,12 +52,12 @@
     .game-hero-band{--section-bg:var(--hero-bg);border-bottom:1px solid var(--line)}
     .game-overview-band{--section-bg:var(--content-bg)}
 
-    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:center}
+    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:start}
     .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:384px;display:grid;place-items:center;padding:0}
     .hero-media img{width:120%;max-width:none;height:auto}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
     .hero-info{display:grid;gap:12px}
-    .hero-heading{display:grid;gap:2px}
+    .hero-heading{display:grid;gap:2px;margin-bottom:4px}
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
 
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em;display:grid;place-items:center;text-align:center;line-height:1.1}
@@ -157,10 +157,10 @@
               </div>
               <div class="hero-info">
                 <div class="hero-heading">
-                  <p class="game-category">ボードゲーム / アクション</p>
                   <h1 id="gameTitle" class="game-title">
                     <img src="../../image/games/seisoin/game-logo.png" alt="静葬員" loading="lazy">
                   </h1>
+                  <p class="game-category">ボードゲーム / アクション</p>
                 </div>
                 <p class="hero-lead">―静かに、葬れ―<br>車ボックスと遺体コマを使って遊ぶミープル運搬バランスアクションゲーム</p>
                 <dl class="game-meta">

--- a/games/template/template.html
+++ b/games/template/template.html
@@ -52,12 +52,12 @@
     .game-hero-band{--section-bg:var(--hero-bg);border-bottom:1px solid var(--line)}
     .game-overview-band{--section-bg:var(--content-bg)}
 
-    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:center}
+    .game-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:start}
     .hero-media{background:transparent;border-radius:var(--radius);overflow:hidden;position:relative;min-height:384px;display:grid;place-items:center;padding:0}
     .hero-media img{width:120%;max-width:none;height:auto}
     .media-fallback{width:100%;height:100%;display:grid;place-items:center;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px);color:var(--ink-weak);font-size:14px;text-align:center;line-height:1.6;padding:20px}
     .hero-info{display:grid;gap:12px}
-    .hero-heading{display:grid;gap:2px}
+    .hero-heading{display:grid;gap:2px;margin-bottom:4px}
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
 
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em;display:grid;place-items:center;text-align:center;line-height:1.1}
@@ -157,12 +157,12 @@
               </div>
               <div class="hero-info">
                 <div class="hero-heading">
-                  <p class="game-category">Game Category</p>
                   <h1 id="gameTitle" class="game-title">
                     <span class="game-title-text">ゲームタイトル</span>
                     <!-- ロゴ画像を使用する場合は以下のimg要素を有効化し、パスと代替テキストを差し替えてください -->
                     <!-- <img src="../../image/games/sample/game-logo.png" alt="Game Title" loading="lazy"> -->
                   </h1>
+                  <p class="game-category">Game Category</p>
                 </div>
                 <p class="hero-lead">ここにゲームのリードテキストを記載します。作品の世界観や魅力が一目で伝わるキャッチコピーや概要を記入してください。</p>
                 <dl class="game-meta">


### PR DESCRIPTION
## Summary
- add a small bottom margin to the hero heading so the category and lead have more separation across all hero layouts

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e235fe82d483258ec0c6e395d655dd