### PR TITLE
Fix Kachikan Kaidan page logo rendering

### DIFF
--- a/games/kachikan-kaidan/kachikan-kaidan.html
+++ b/games/kachikan-kaidan/kachikan-kaidan.html
@@ -24,6 +24,7 @@
     }
 
     *,*::before,*::after{box-sizing:border-box}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     html,body{height:100%}
     body{
       margin:0;
@@ -166,7 +167,8 @@
               <div class="hero-info">
                 <div class="hero-heading">
                   <h1 id="gameTitle" class="game-title">
-                    <span class="game-title-text">カチカン会談〜ウワサの二人を知らない僕ら〜</span>
+                    <span class="sr-only">カチカン会談〜ウワサの二人を知らない僕ら〜</span>
+                    <img src="../../image/games/kachikan/kachikan_logo.png" alt="">
                   </h1>
                   <p class="game-category">ボードゲーム / パーティー / 恋愛</p>
                 </div>


### PR DESCRIPTION
## Summary
- display the dedicated logo image for the Kachikan Kaidan game detail page
- add a reusable sr-only helper class so the heading retains accessible text while showing the logo artwork

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60e5947788325a9d98e89b0948ef9