### PR TITLE
Restore original Meishi logo asset

### DIFF
--- a/games/meishi/meishi.html
+++ b/games/meishi/meishi.html
@@ -61,7 +61,6 @@
     .game-category{font-size:13px;letter-spacing:.32em;text-transform:uppercase;color:var(--ink-weak)}
 
     .game-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:40px;letter-spacing:.04em;display:grid;place-items:start;justify-items:start;text-align:left;line-height:1.1}
-    .game-title-text{display:block}
     .game-title img{width:100%;height:auto;margin:0 auto;display:block}
     .game-meta{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0;padding:0;border-radius:var(--panel-radius);background:rgba(255,255,255,.04);border:1px solid var(--line);overflow:hidden}
     .game-meta>div{position:relative;padding:18px 16px;display:grid;gap:6px;justify-items:center}
@@ -167,7 +166,7 @@
               <div class="hero-info">
                 <div class="hero-heading">
                   <h1 id="gameTitle" class="game-title">
-                    <span class="game-title-text">名刺の管理ができません</span>
+                    <img src="../../image/games/meishi/meishi_logo.png" alt="名刺の管理ができませんのロゴ" loading="lazy">
                   </h1>
                   <p class="game-category">ボードゲーム / カルタ</p>
                 </div>


### PR DESCRIPTION
## Summary
- restore the Meishi detail page logo graphic to the repository-provided image so the page uses the intended asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60dec80448325b764d43b913b8821