### PR TITLE
Fix Informer links to detail page

### DIFF
--- a/games/games.html
+++ b/games/games.html
@@ -116,7 +116,7 @@
           <a class="gallery-tile" href="absepture/absepture.html" aria-label="アブセプチャー" style="--tile-bg:#2b3a4c">
             <img src="../image/games/abcepture/abcepture.png" alt="アブセプチャー" loading="lazy">
           </a>
-          <a class="gallery-tile" href="#" aria-label="インフォーマー" style="--tile-bg:#28334a">
+          <a class="gallery-tile" href="informer/informer-r.html" aria-label="インフォーマー" style="--tile-bg:#28334a">
             <img src="../image/games/informer/informer.png" alt="インフォーマー" loading="lazy">
           </a>
           <span class="gallery-tile placeholder" aria-hidden="true"></span>

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@ document.addEventListener('DOMContentLoaded', function(){
     {id:'comical',     title:'コミカルミッション',     img:'image/games/comical/comical.png',   link:'games/comical_mission/comical_mission.html'},
     {id:'kachikan',    title:'カチカン会談',           img:'image/games/kachikan/kachikan.png',  link:'games/kachikan-kaidan/kachikan-kaidan.html'},
     {id:'abception',   title:'アブセプチャー',         img:'image/games/abcepture/abcepture.png', link:'games/absepture/absepture.html'},
-    {id:'informer',    title:'インフォーマー',         img:'image/games/informer/informer.png',  link:'#game-informer'}
+    {id:'informer',    title:'インフォーマー',         img:'image/games/informer/informer.png',  link:'games/informer/informer-r.html'}
   ];
 
   const MEMBERS = [


### PR DESCRIPTION
## Summary
- point the Informer card on the top page to the Informer Returns detail page
- update the games gallery Informer card to link to the Informer Returns detail page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e625bdb9d08325a5119e1b3455d87e