### PR TITLE
Ensure game prices show tax inclusion

### DIFF
--- a/games/absepture/absepture.html
+++ b/games/absepture/absepture.html
@@ -85,7 +85,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}
@@ -182,7 +182,7 @@
                 </dl>
                 <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
-                    <span class="purchase-price">￥1,500</span>
+                    <span class="purchase-price">￥1,500（税込）</span>
                     <a class="cta-button" href="https://booth.pm/ja/items/1934044" target="_blank" rel="noopener noreferrer">BOOTHで購入</a>
                   </div>
                   <p class="purchase-note">※ 外部サイト「BOOTH」の商品ページに移動します。</p>

--- a/games/comical_mission/comical_mission.html
+++ b/games/comical_mission/comical_mission.html
@@ -91,7 +91,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
     .cta-button.is-disabled{background:#707680;color:var(--ink);opacity:.6;box-shadow:none;pointer-events:none}
 
@@ -196,7 +196,7 @@
                 </dl>
                 <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
-                    <span class="purchase-price">￥1,500</span>
+                    <span class="purchase-price">￥1,500（税込）</span>
                     <a class="cta-button" href="https://booth.pm/ja/items/4313433" target="_blank" rel="noopener noreferrer">BOOTHで購入</a>
                   </div>
                   <p class="purchase-note">※ 外部サイト「BOOTH」の商品ページに移動します。</p>

--- a/games/escape-goat/escape-goat.html
+++ b/games/escape-goat/escape-goat.html
@@ -84,7 +84,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
     .cta-button.is-disabled{background:#707680;color:var(--ink);opacity:.6;box-shadow:none;pointer-events:none}
 
@@ -188,7 +188,7 @@
                 </dl>
                 <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
-                    <span class="purchase-price">￥2,000（税込）</span>
+                    <span class="purchase-price">￥1,500（税込）</span>
                     <span class="cta-button is-disabled" aria-disabled="true">準備中</span>
                   </div>
                   <p class="purchase-note">※ 販売ページの公開までしばらくお待ちください。</p>

--- a/games/informer/informer-r.html
+++ b/games/informer/informer-r.html
@@ -84,7 +84,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}

--- a/games/kachikan-kaidan/kachikan-kaidan.html
+++ b/games/kachikan-kaidan/kachikan-kaidan.html
@@ -85,7 +85,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}

--- a/games/meishi/meishi.html
+++ b/games/meishi/meishi.html
@@ -84,7 +84,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}
@@ -187,7 +187,7 @@
                 </dl>
                 <section class="purchase-block" aria-label="購入情報">
                   <div class="purchase-cta">
-                    <span class="purchase-price">￥1,000</span>
+                    <span class="purchase-price">￥1,000（税込）</span>
                     <a class="cta-button" href="https://booth.pm/ja/items/5697977?srsltid=AfmBOop6gGldoArlRTcmSE5M0bZ5VCUBQ0lKGu9-4D5qSG5lpoq6hWus" target="_blank" rel="noopener noreferrer">BOOTHで購入</a>
                   </div>
                   <p class="purchase-note">※ 外部サイト「BOOTH」の商品ページに移動します。</p>

--- a/games/seisoin/seisoin.html
+++ b/games/seisoin/seisoin.html
@@ -84,7 +84,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}

--- a/games/template/template.html
+++ b/games/template/template.html
@@ -84,7 +84,7 @@
     .purchase-cta>*{width:100%;text-align:center}
     .cta-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 22px;border-radius:var(--panel-radius);background:var(--accent);color:var(--bg);font-weight:700;font-size:15px;letter-spacing:.06em;border:none;box-shadow:0 6px 16px rgba(0,0,0,.28);transition:transform .18s ease,box-shadow .18s ease,background-color .18s ease;width:100%}
     .cta-button:hover{transform:translateY(-1px);box-shadow:0 10px 20px rgba(0,0,0,.3);background:#ffc55d;color:var(--bg)}
-    .purchase-price{font-size:24px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
+    .purchase-price{font-size:22px;font-weight:700;letter-spacing:.06em;display:flex;align-items:center;justify-content:center;line-height:1.4;width:100%}
     .purchase-note{font-size:13px;color:var(--ink-weak)}
 
     .overview-media{display:grid;gap:24px}


### PR DESCRIPTION
## Summary
- add missing tax-inclusive notation to game detail pricing and correct the Escape Goat price to ¥1,500
- reduce the purchase price font size across game detail pages (and template) for a more balanced layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6522766288325b3ab8ede54464f21