### PR TITLE
Remove binary news images and adjust template styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
       <section id="news" class="ps-section ps-news" aria-label="ニュース">
         <h2>NEWS</h2>
         <div class="ps-news-list" id="newsList"></div>
-        <div class="ps-news-actions"><a class="btn ps-news-more" href="#">More</a></div>
+        <div class="ps-news-actions"><a class="btn ps-news-more" href="news/2025-11-01/2025-11-01.html">More</a></div>
       </section>
 
       <section id="games" class="ps-section ps-games" aria-label="ゲーム一覧">
@@ -529,8 +529,17 @@ document.addEventListener('DOMContentLoaded', function(){
   (function(){
     const newsList=document.getElementById('newsList');
     if(!newsList) return;
-    [['10/1','公式サイトリニューアルについて'],['10/2','2025秋 ゲームマーケット出展のお知らせ'],['10/3', '新作 ゆめゆめ情報解禁']]
-      .forEach(([d,t])=>{ const a=document.createElement('a'); a.href='#'; a.className='ps-news-item'; a.innerHTML=`<div class='ps-news-time'>${d}</div><div>${t}</div><div class='ps-news-arrow'>→</div>`; newsList.appendChild(a); });
+    const NEWS = [
+      {date:'11/1', title:'公式サイトリニューアルについて', href:'news/2025-11-01/2025-11-01.html'}
+    ];
+
+    NEWS.forEach(({date, title, href})=>{
+      const a=document.createElement('a');
+      a.href=href || '#';
+      a.className='ps-news-item';
+      a.innerHTML=`<div class='ps-news-time'>${date}</div><div>${title}</div><div class='ps-news-arrow'>→</div>`;
+      newsList.appendChild(a);
+    });
   })();
 
   // ===== Games grid (left) =====

--- a/news/2025-11-01/2025-11-01.html
+++ b/news/2025-11-01/2025-11-01.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>公式サイトリニューアル – Pentas Studio</title>
+  <link rel="icon" type="image/png" href="../../image/general/logo.png" />
+  <link href="https://fonts.googleapis.com/css2?family=Rampart+One&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@500;700&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#29323b;
+      --surface:#1f2730;
+      --surface-soft:#212a33;
+      --ink:#eff3f8;
+      --ink-weak:#aeb8c4;
+      --ink-soft:#d7dee7;
+      --line:#394656;
+      --accent:#FFBA3A;
+      --radius:18px;
+      --panel-radius:14px;
+      --shadow:0 12px 28px rgba(0,0,0,.28);
+      --page-pad:min(max(5vw,22px),56px);
+      --hero-media-min:360px;
+    }
+
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0;
+      background:var(--bg);
+      color:var(--ink);
+      font-family:"Hiragino Kaku Gothic ProN","Noto Sans JP","BIZ UDGothic","Yu Gothic",Meiryo,sans-serif;
+      line-height:1.8;
+      -webkit-font-smoothing:antialiased;
+    }
+    img{display:block;max-width:100%;height:auto;user-select:none;-webkit-user-drag:none}
+    a{color:inherit;text-decoration:none}
+    h1,h2,h3,p,ul{margin:0}
+
+    .page{min-height:100vh;display:grid;grid-template-rows:auto 1fr auto}
+
+    header{
+      padding:30px var(--page-pad) 22px;
+      display:grid;
+      gap:18px;
+      justify-items:center;
+      text-align:center;
+      border-bottom:1px solid var(--line);
+      background:rgba(31,39,48,.92);
+      box-shadow:0 20px 40px rgba(0,0,0,.28);
+    }
+    .brand-logo{width:120px;height:120px;border-radius:50%;overflow:hidden;display:grid;place-items:center;background:transparent}
+    .brand-logo img{width:100%;height:100%;object-fit:contain}
+    .brand-name{font-family:'Rampart One',system-ui,sans-serif;font-size:32px;letter-spacing:.02em}
+    .brand-name img{max-height:78px;object-fit:contain;margin:0 auto}
+
+    main{display:grid;gap:0}
+    .section-band{padding:56px var(--page-pad);display:flex;justify-content:center;background:var(--section-bg,#0000)}
+    .band-inner{width:min(1080px,100%);display:grid;gap:0}
+
+    .entry-hero-band{--section-bg:var(--surface-soft);border-bottom:1px solid var(--line)}
+    .entry-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:start}
+    .hero-media{border-radius:var(--radius);overflow:hidden;background:rgba(16,21,28,.8);border:1px solid rgba(255,255,255,.08);min-height:var(--hero-media-min);display:grid;place-items:center;box-shadow:0 8px 22px rgba(0,0,0,.22)}
+    .hero-media img{width:100%;height:100%;object-fit:cover}
+    .hero-info{display:grid;gap:22px;align-content:flex-start}
+    .entry-category{font-size:12px;letter-spacing:.32em;text-transform:uppercase;color:var(--accent)}
+    .entry-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:52px;font-weight:700;letter-spacing:.02em;line-height:1.15;margin:0}
+    .entry-meta-inline{display:flex;flex-wrap:wrap;gap:16px 24px;align-items:center}
+    .entry-published{font-size:14px;letter-spacing:.16em;color:var(--ink-weak);display:flex;align-items:center;gap:10px}
+    .entry-published::before{content:"";width:12px;height:12px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 4px rgba(255,186,58,.18)}
+    .entry-published time{font-variant-numeric:tabular-nums;color:var(--ink);letter-spacing:.18em}
+    .entry-author{display:flex;align-items:center;gap:14px;padding:8px 12px;border-radius:999px;background:rgba(24,32,42,.78);border:1px solid rgba(255,255,255,.08);box-shadow:0 12px 24px rgba(0,0,0,.24)}
+    .author-avatar{width:48px;height:48px;border-radius:50%;overflow:hidden;background:rgba(255,255,255,.1);display:grid;place-items:center}
+    .author-avatar img{width:100%;height:100%;object-fit:cover}
+    .author-meta{display:grid;gap:4px}
+    .author-role{font-size:12px;letter-spacing:.1em;color:var(--ink-weak)}
+    .author-name{font-size:16px;font-weight:700;letter-spacing:.12em}
+
+    .entry-body-band{--section-bg:var(--surface)}
+    .entry-body{width:min(760px,100%);margin:0 auto;display:grid;gap:28px}
+    .entry-body p{margin:0;font-size:16px;line-height:2;color:#e4eaf1;letter-spacing:.01em}
+    .entry-body p + p{margin-top:-4px}
+    .entry-body strong{color:var(--accent)}
+    .entry-body figure{margin:0;border-radius:var(--radius);overflow:hidden;background:rgba(20,27,35,.72);border:1px solid rgba(255,255,255,.08)}
+    .entry-body figure img{width:100%;height:auto;display:block}
+    .entry-body blockquote{margin:0;padding:24px 28px;border-left:4px solid var(--accent);background:rgba(16,22,30,.78);border-radius:0 var(--radius) var(--radius) 0;color:#eaf1f7;font-size:16px;line-height:1.9}
+    .entry-body blockquote cite{display:block;margin-top:12px;font-size:13px;letter-spacing:.08em;color:var(--ink-weak)}
+    .entry-body hr{border:none;border-top:1px solid rgba(255,255,255,.08);margin:18px 0 12px}
+    .entry-body code{font-family:"SFMono-Regular","Consolas","BIZ UDGothic",monospace;font-size:.94em;background:rgba(255,255,255,.08);padding:2px 8px;border-radius:6px;color:var(--ink-soft)}
+
+    footer{padding:32px var(--page-pad) 42px;border-top:1px solid var(--line);display:grid;gap:14px;justify-items:center;background:rgba(23,30,39,.94)}
+    .sns{display:flex;gap:12px;justify-content:center}
+    .sns a{width:46px;height:46px;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#ffffff12;border:1px solid var(--line);color:var(--ink);transition:transform .18s ease,background-color .18s ease,box-shadow .18s ease,color .18s ease;--sns-play:var(--bg)}
+    .sns a:hover{transform:scale(1.06);background:var(--accent);color:var(--bg);box-shadow:var(--shadow);border-color:transparent;--sns-play:var(--ink)}
+    .sns svg{width:20px;height:20px}
+    .sns path{fill:currentColor}
+    .sns path.play{fill:var(--sns-play);transition:fill .18s ease}
+    .footer-copy{margin:0;color:var(--ink-weak);font-size:12px;letter-spacing:.04em;text-align:center}
+
+    @media (max-width:1023px){
+      :root{--page-pad:min(max(4vw,18px),44px)}
+      .entry-hero{grid-template-columns:1fr;gap:28px}
+      .hero-media{order:-1;min-height:320px}
+      .entry-title{font-size:44px}
+    }
+    @media (max-width:639px){
+      header{padding-top:24px}
+      .brand-name{font-size:28px}
+      .section-band{padding:40px var(--page-pad)}
+      .entry-title{font-size:34px}
+      .entry-body{gap:24px}
+      .entry-body p{font-size:15px}
+      .entry-author{width:100%;justify-content:flex-start}
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header aria-label="サイトヘッダー">
+      <a class="brand-logo" href="../../index.html?skipLoading=1#top" aria-label="トップページへ戻る">
+        <img src="../../image/general/logo.png" alt="Pentas Studio" loading="lazy">
+      </a>
+      <div class="brand-name">
+        <img src="../../image/general/let_logo.png" alt="Pentas Studio" loading="lazy">
+      </div>
+    </header>
+
+    <main>
+      <article aria-labelledby="entryTitle">
+        <section class="section-band entry-hero-band">
+          <div class="band-inner">
+            <div class="entry-hero">
+              <figure class="hero-media" aria-label="リニューアルのキービジュアル">
+                <img src="thumbnail.png" alt="公式サイトに掲出しているペンタススタジオのロゴ" loading="lazy">
+              </figure>
+              <div class="hero-info">
+                <p class="entry-category">INFO</p>
+                <h1 id="entryTitle" class="entry-title">公式サイトリニューアル</h1>
+                <div class="entry-meta-inline">
+                  <p class="entry-published"><time datetime="2025-11-01">2025.11.01</time> 公開</p>
+                  <div class="entry-author">
+                    <div class="author-avatar" aria-hidden="true">
+                      <img src="../../image/menbers/matsuki.jpg" alt="マツキハジメのポートレート写真" loading="lazy">
+                    </div>
+                    <div class="author-meta">
+                      <span class="author-role">ゲームデザイン / エンジニア</span>
+                      <span class="author-name">マツキハジメ</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section-band entry-body-band">
+          <div class="band-inner">
+            <div class="entry-body">
+              <p>リニューアルの出発点は、ゲーム作品のディテールと開発背景を同じ熱量で伝えたいという思いでした。各ゲームページで培ったレイアウトをベースに、ブログも一つの作品紹介ページのように扱えるようデザインを揃えています。トップのヒーローはゲーム詳細ページさながらの構成に整え、訪れた瞬間に世界観が伝わるようにしました。</p>
+              <figure>
+                <img src="main_visual.png" alt="ギャラリー形式で並んだペンタススタジオのボードゲーム作品">
+              </figure>
+              <p>本文は章立てを作らず、段落を重ねながら制作の裏側を語るスタイルに。ゲームの概要ブロックで行っているような丁寧な説明を文章の流れに溶け込ませ、<strong>チームが大切にした変更点や空気感</strong>がそのまま感じられるようにしています。アクセントにしたい箇所のみ太字で装飾し、余白を活かした読み心地を重視しました。</p>
+              <blockquote>
+                今回のリニューアルで一番こだわったのは、「好きな作品の話をするテンポ感」をそのままサイトに落とし込むこと。情報が増えたことで迷わせてしまわないよう、1カラムで視線の流れをそろえています。
+                <cite>— Pentas Studio Web チーム</cite>
+              </blockquote>
+              <p>今後は INFO カテゴリの更新をこのテンプレートに揃えることで、開発ログやイベントレポートも同じリズムで読んでいただけます。これからも公式サイトの改善や制作の裏側を、ブログのような温度感でお届けしていきます。</p>
+            </div>
+          </div>
+        </section>
+      </article>
+    </main>
+
+    <footer aria-label="フッター">
+      <div class="sns" aria-label="SNSリンク">
+        <a href="https://x.com/bdg_de_asobo" aria-label="X" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18.244 3H21.5l-7.52 8.59L22 21h-6.31l-4.94-6.43L4.81 21H1.5l7.81-8.93L2 3h6.31l4.5 5.84L18.244 3Z"/>
+          </svg>
+        </a>
+        <a href="https://www.youtube.com/@%E3%83%9A%E3%83%B3%E3%82%BF%E3%82%B9%E3%82%B9%E3%82%BF%E3%82%B8%E3%82%AA" aria-label="YouTube" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M21.6 7.6a2 2 0 0 0-1.4-1.4C18.7 5.8 12 5.8 12 5.8s-6.7 0-8.2.4A2 2 0 0 0 2.4 7.6C2 9.1 2 12 2 12s0 2.9.4 4.4a2 2 0 0 0 1.4 1.4c1.5.4 8.2.4 8.2.4s6.7 0 8.2-.4a2 2 0 0 0 1.4-1.4c.4-1.5.4-4.4.4-4.4s0-2.9-.4-4.4Z"/>
+            <path class="play" d="M10.5 9.75v4.5L15 12l-4.5-2.25Z"/>
+          </svg>
+        </a>
+        <a href="https://pentasufide.booth.pm/" aria-label="BOOTH ショップ" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16l-1.2 8.4a2 2 0 0 1-2 1.6H8.2l-.4 2h10.7v2H6a1 1 0 0 1-1-.8L3 6Z"/>
+            <path d="M9 18H7.2L5.5 8h13l-.9 6.2a2 2 0 0 1-2 1.6H9Z"/>
+          </svg>
+        </a>
+      </div>
+      <p class="footer-copy">© pantas studio All Right Reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/news/template.html
+++ b/news/template.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>News Template – Pentas Studio</title>
+  <link rel="icon" type="image/png" href="../image/general/logo.png" />
+  <link href="https://fonts.googleapis.com/css2?family=Rampart+One&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@500;700&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#29323b;
+      --surface:#1f2730;
+      --surface-soft:#212a33;
+      --ink:#eff3f8;
+      --ink-weak:#aeb8c4;
+      --ink-soft:#d7dee7;
+      --line:#394656;
+      --accent:#FFBA3A;
+      --radius:18px;
+      --panel-radius:14px;
+      --shadow:0 12px 28px rgba(0,0,0,.28);
+      --page-pad:min(max(5vw,22px),56px);
+      --hero-media-min:360px;
+    }
+
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0;
+      background:var(--bg);
+      color:var(--ink);
+      font-family:"Hiragino Kaku Gothic ProN","Noto Sans JP","BIZ UDGothic","Yu Gothic",Meiryo,sans-serif;
+      line-height:1.8;
+      -webkit-font-smoothing:antialiased;
+    }
+    img{display:block;max-width:100%;height:auto;user-select:none;-webkit-user-drag:none}
+    a{color:inherit;text-decoration:none}
+    h1,h2,h3,p,ul{margin:0}
+
+    .page{min-height:100vh;display:grid;grid-template-rows:auto 1fr auto}
+
+    header{
+      padding:30px var(--page-pad) 22px;
+      display:grid;
+      gap:18px;
+      justify-items:center;
+      text-align:center;
+      border-bottom:1px solid var(--line);
+      background:rgba(31,39,48,.92);
+      box-shadow:0 20px 40px rgba(0,0,0,.28);
+    }
+    .brand-logo{width:120px;height:120px;border-radius:50%;overflow:hidden;display:grid;place-items:center;background:transparent}
+    .brand-logo img{width:100%;height:100%;object-fit:contain}
+    .brand-name{font-family:'Rampart One',system-ui,sans-serif;font-size:32px;letter-spacing:.02em}
+    .brand-name img{max-height:78px;object-fit:contain;margin:0 auto}
+
+    main{display:grid;gap:0}
+    .section-band{padding:56px var(--page-pad);display:flex;justify-content:center;background:var(--section-bg,#0000)}
+    .band-inner{width:min(1080px,100%);display:grid;gap:0}
+
+    .entry-hero-band{--section-bg:var(--surface-soft);border-bottom:1px solid var(--line)}
+    .entry-hero{display:grid;grid-template-columns:1.32fr 1fr;gap:36px;align-items:start}
+    .hero-media{border-radius:var(--radius);overflow:hidden;background:rgba(16,21,28,.8);border:1px solid rgba(255,255,255,.08);min-height:var(--hero-media-min);display:grid;place-items:center;box-shadow:0 8px 22px rgba(0,0,0,.22)}
+    .hero-media img{width:100%;height:100%;object-fit:cover}
+    .hero-fallback{width:100%;height:100%;display:grid;place-items:center;padding:32px;color:var(--ink-weak);text-align:center;letter-spacing:.06em;border:2px dashed rgba(255,255,255,.18);border-radius:calc(var(--radius) - 6px)}
+    .hero-info{display:grid;gap:22px;align-content:flex-start}
+    .entry-category{font-size:12px;letter-spacing:.32em;text-transform:uppercase;color:var(--accent)}
+    .entry-title{font-family:'Zen Kaku Gothic New','Hiragino Kaku Gothic ProN','Noto Sans JP','BIZ UDGothic','Yu Gothic',Meiryo,sans-serif;font-size:52px;font-weight:700;letter-spacing:.02em;line-height:1.15;margin:0}
+    .entry-meta-inline{display:flex;flex-wrap:wrap;gap:16px 24px;align-items:center}
+    .entry-published{font-size:14px;letter-spacing:.16em;color:var(--ink-weak);display:flex;align-items:center;gap:10px}
+    .entry-published::before{content:"";width:12px;height:12px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 4px rgba(255,186,58,.18)}
+    .entry-published time{font-variant-numeric:tabular-nums;color:var(--ink);letter-spacing:.18em}
+    .entry-author{display:flex;align-items:center;gap:14px;padding:8px 12px;border-radius:999px;background:rgba(24,32,42,.78);border:1px solid rgba(255,255,255,.08);box-shadow:0 12px 24px rgba(0,0,0,.24)}
+    .author-avatar{width:48px;height:48px;border-radius:50%;overflow:hidden;background:rgba(255,255,255,.1);display:grid;place-items:center}
+    .author-avatar img{width:100%;height:100%;object-fit:cover}
+    .author-meta{display:grid;gap:4px}
+    .author-role{font-size:12px;letter-spacing:.1em;color:var(--ink-weak)}
+    .author-name{font-size:16px;font-weight:700;letter-spacing:.12em}
+
+    .entry-body-band{--section-bg:var(--surface)}
+    .entry-body{width:min(760px,100%);margin:0 auto;display:grid;gap:28px}
+    .entry-body p{margin:0;font-size:16px;line-height:2;color:#e4eaf1;letter-spacing:.01em}
+    .entry-body p + p{margin-top:-4px}
+    .entry-body strong{color:var(--accent)}
+    .entry-body figure{margin:0;border-radius:var(--radius);overflow:hidden;background:rgba(20,27,35,.72);border:1px solid rgba(255,255,255,.08)}
+    .entry-body figure img{width:100%;height:auto;display:block}
+    .entry-body blockquote{margin:0;padding:24px 28px;border-left:4px solid var(--accent);background:rgba(16,22,30,.78);border-radius:0 var(--radius) var(--radius) 0;color:#eaf1f7;font-size:16px;line-height:1.9}
+    .entry-body blockquote cite{display:block;margin-top:12px;font-size:13px;letter-spacing:.08em;color:var(--ink-weak)}
+    .entry-body hr{border:none;border-top:1px solid rgba(255,255,255,.08);margin:18px 0 12px}
+    .entry-body code{font-family:"SFMono-Regular","Consolas","BIZ UDGothic",monospace;font-size:.94em;background:rgba(255,255,255,.08);padding:2px 8px;border-radius:6px;color:var(--ink-soft)}
+
+    footer{padding:32px var(--page-pad) 42px;border-top:1px solid var(--line);display:grid;gap:14px;justify-items:center;background:rgba(23,30,39,.94)}
+    .sns{display:flex;gap:12px;justify-content:center}
+    .sns a{width:46px;height:46px;border-radius:50%;display:flex;align-items:center;justify-content:center;background:#ffffff12;border:1px solid var(--line);color:var(--ink);transition:transform .18s ease,background-color .18s ease,box-shadow .18s ease,color .18s ease;--sns-play:var(--bg)}
+    .sns a:hover{transform:scale(1.06);background:var(--accent);color:var(--bg);box-shadow:var(--shadow);border-color:transparent;--sns-play:var(--ink)}
+    .sns svg{width:20px;height:20px}
+    .sns path{fill:currentColor}
+    .sns path.play{fill:var(--sns-play);transition:fill .18s ease}
+    .footer-copy{margin:0;color:var(--ink-weak);font-size:12px;letter-spacing:.04em;text-align:center}
+
+    @media (max-width:1023px){
+      :root{--page-pad:min(max(4vw,18px),44px)}
+      .entry-hero{grid-template-columns:1fr;gap:28px}
+      .hero-media{order:-1;min-height:320px}
+      .entry-title{font-size:44px}
+    }
+    @media (max-width:639px){
+      header{padding-top:24px}
+      .brand-name{font-size:28px}
+      .section-band{padding:40px var(--page-pad)}
+      .entry-title{font-size:34px}
+      .entry-body{gap:24px}
+      .entry-body p{font-size:15px}
+      .entry-author{width:100%;justify-content:flex-start}
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header aria-label="サイトヘッダー">
+      <a class="brand-logo" href="../index.html?skipLoading=1#top" aria-label="トップページへ戻る">
+        <img src="../image/general/logo.png" alt="Pentas Studio" loading="lazy">
+      </a>
+      <div class="brand-name">
+        <img src="../image/general/let_logo.png" alt="Pentas Studio" loading="lazy">
+      </div>
+    </header>
+
+    <main>
+      <article aria-labelledby="entryTitle">
+        <section class="section-band entry-hero-band">
+          <div class="band-inner">
+            <div class="entry-hero">
+              <figure class="hero-media" aria-label="キービジュアル">
+                <div class="hero-fallback">このページと同じフォルダに <code>thumbnail.png</code> を配置すると表示されます<br>推奨サイズ：2400×1500px</div>
+              </figure>
+              <div class="hero-info">
+                <p class="entry-category">INFO</p>
+                <h1 id="entryTitle" class="entry-title">ニュースタイトルが入ります</h1>
+                <div class="entry-meta-inline">
+                  <p class="entry-published"><time datetime="2024-01-01">2024.01.01</time> 公開</p>
+                  <div class="entry-author">
+                    <div class="author-avatar" aria-hidden="true">
+                      <img src="../image/menbers/matsuki.jpg" alt="マツキハジメのポートレート写真" loading="lazy">
+                    </div>
+                    <div class="author-meta">
+                      <span class="author-role">ゲームデザイン / エンジニア</span>
+                      <span class="author-name">マツキハジメ</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section-band entry-body-band">
+          <div class="band-inner">
+            <div class="entry-body">
+              <p>本文はゲーム紹介ページのリッチな余白感を活かしつつも、読み進めやすい1カラムレイアウトで構成します。段落ごとに体験や背景を語り、訪れた人が流れるように内容を追えることを意識してください。</p>
+              <figure>
+                <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'%3E%3Crect width='1200' height='800' fill='%23212a33'/%3E%3Crect x='120' y='120' width='960' height='560' rx='28' fill='%23FFBA3A' opacity='.12'/%3E%3Ctext x='50%25' y='50%25' fill='%23FFBA3A' font-family='Zen Kaku Gothic New' font-size='40' text-anchor='middle'%3Emain_visual.png%3C/text%3E%3C/svg%3E" alt="メインビジュアルのプレースホルダー">
+              </figure>
+              <p>強調したいポイントは <strong>太字</strong> でアクセントを付けたり、リンクを挿入して関連情報へ誘導します。必要に応じて図版や写真を <code>figure</code> 要素で差し込み、本文の流れを崩さないよう短いコメントで補足するのがおすすめです。</p>
+              <blockquote>
+                リニューアルやイベントの背景にある想いを引用として挟み込むことで、記事全体のリズムをつくることができます。読者の目を引きたいメッセージがあれば短くまとめてください。
+                <cite>— 記事制作チーム</cite>
+              </blockquote>
+              <p>締めくくりには今後の予定や読者へのメッセージを書き添え、記事を訪れた人が次のアクションを取りやすいよう導線を整えてください。</p>
+            </div>
+          </div>
+        </section>
+      </article>
+    </main>
+
+    <footer aria-label="フッター">
+      <div class="sns" aria-label="SNSリンク">
+        <a href="https://x.com/bdg_de_asobo" aria-label="X" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18.244 3H21.5l-7.52 8.59L22 21h-6.31l-4.94-6.43L4.81 21H1.5l7.81-8.93L2 3h6.31l4.5 5.84L18.244 3Z"/>
+          </svg>
+        </a>
+        <a href="https://www.youtube.com/@%E3%83%9A%E3%83%B3%E3%82%BF%E3%82%B9%E3%82%B9%E3%82%BF%E3%82%B8%E3%82%AA" aria-label="YouTube" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M21.6 7.6a2 2 0 0 0-1.4-1.4C18.7 5.8 12 5.8 12 5.8s-6.7 0-8.2.4A2 2 0 0 0 2.4 7.6C2 9.1 2 12 2 12s0 2.9.4 4.4a2 2 0 0 0 1.4 1.4c1.5.4 8.2.4 8.2.4s6.7 0 8.2-.4a2 2 0 0 0 1.4-1.4c.4-1.5.4-4.4.4-4.4s0-2.9-.4-4.4Z"/>
+            <path class="play" d="M10.5 9.75v4.5L15 12l-4.5-2.25Z"/>
+          </svg>
+        </a>
+        <a href="https://pentasufide.booth.pm/" aria-label="BOOTH ショップ" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 6h16l-1.2 8.4a2 2 0 0 1-2 1.6H8.2l-.4 2h10.7v2H6a1 1 0 0 1-1-.8L3 6Z"/>
+            <path d="M9 18H7.2L5.5 8h13l-.9 6.2a2 2 0 0 1-2 1.6H9Z"/>
+          </svg>
+        </a>
+      </div>
+      <p class="footer-copy">© pantas studio All Right Reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove the committed PNG assets from the 2025-11-01 news article directory to keep the PR binary-free
- soften the hero thumbnail shadow and remove the unused figcaption styling in both the article and the template
- refresh the template copy so it no longer references image captions

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68e90a63b1e883259c87648fedb064dd