### PR TITLE
Allow strong text to opt into accent or ink emphasis

### DIFF
--- a/games/absepture/absepture.html
+++ b/games/absepture/absepture.html
@@ -75,6 +75,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/comical_mission/comical_mission.html
+++ b/games/comical_mission/comical_mission.html
@@ -75,6 +75,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/escape-goat/escape-goat.html
+++ b/games/escape-goat/escape-goat.html
@@ -74,6 +74,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/informer/informer-r.html
+++ b/games/informer/informer-r.html
@@ -74,6 +74,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/kachikan-kaidan/kachikan-kaidan.html
+++ b/games/kachikan-kaidan/kachikan-kaidan.html
@@ -75,6 +75,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/meishi/meishi.html
+++ b/games/meishi/meishi.html
@@ -74,6 +74,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/seisoin/seisoin.html
+++ b/games/seisoin/seisoin.html
@@ -74,6 +74,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/games/template/template.html
+++ b/games/template/template.html
@@ -74,6 +74,10 @@
     .overview-block{display:grid;gap:14px;background:rgba(31,39,48,.72);border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
     .overview-block h2{font-size:22px;letter-spacing:.08em}
     .overview-block p{font-size:15px;line-height:1.9;color:#d7dee8}
+    .overview-block strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .overview-block strong.is-ink,
+    .overview-block strong[data-variant="ink"]{color:var(--ink)}
     .component-list{margin:0;padding-left:20px;display:grid;gap:6px;font-size:15px;line-height:1.8;color:#d7dee8}
     .component-note{font-size:13px;line-height:1.8;color:var(--ink-weak)}
 

--- a/news/2025-11-01/2025-11-01.html
+++ b/news/2025-11-01/2025-11-01.html
@@ -82,6 +82,9 @@
     .entry-body p{margin:0;font-size:16px;line-height:2;color:#e4eaf1;letter-spacing:.01em}
     .entry-body p + p{margin-top:-4px}
     .entry-body strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .entry-body strong.is-ink,
+    .entry-body strong[data-variant="ink"]{color:var(--ink)}
     .entry-body figure{margin:0;border-radius:var(--radius);overflow:hidden;background:rgba(20,27,35,.72);border:1px solid rgba(255,255,255,.08)}
     .entry-body figure img{width:100%;height:auto;display:block}
     .entry-body blockquote{margin:0;padding:24px 28px;border-left:4px solid var(--accent);background:rgba(16,22,30,.78);border-radius:0 var(--radius) var(--radius) 0;color:#eaf1f7;font-size:16px;line-height:1.9}
@@ -157,7 +160,7 @@
         <section class="section-band entry-body-band">
           <div class="band-inner">
             <div class="entry-body">
-              <p>はじめまして！<strong>ペンタススタジオ</strong>です！<br>この度、新しくペンタススタジオのホームページを開設いたしました！</p>
+              <p>はじめまして！<strong data-variant="ink">ペンタススタジオ</strong>です！<br>この度、新しくペンタススタジオのホームページを開設いたしました！</p>
               <!--figure>
                 <img src="main_visual.png" alt="ギャラリー形式で並んだペンタススタジオのボードゲーム作品">
               </figure-->

--- a/news/template.html
+++ b/news/template.html
@@ -83,6 +83,9 @@
     .entry-body p{margin:0;font-size:16px;line-height:2;color:#e4eaf1;letter-spacing:.01em}
     .entry-body p + p{margin-top:-4px}
     .entry-body strong{color:var(--accent)}
+    /* data-variant="ink" または .is-ink で白い強調に切り替え */
+    .entry-body strong.is-ink,
+    .entry-body strong[data-variant="ink"]{color:var(--ink)}
     .entry-body figure{margin:0;border-radius:var(--radius);overflow:hidden;background:rgba(20,27,35,.72);border:1px solid rgba(255,255,255,.08)}
     .entry-body figure img{width:100%;height:auto;display:block}
     .entry-body blockquote{margin:0;padding:24px 28px;border-left:4px solid var(--accent);background:rgba(16,22,30,.78);border-radius:0 var(--radius) var(--radius) 0;color:#eaf1f7;font-size:16px;line-height:1.9}


### PR DESCRIPTION
## Summary
- allow the strong text styles on each game overview page to opt into white text via `.is-ink` or `data-variant="ink"`
- apply the same helper to news article layouts and use it to keep the brand name highlighted in white on the renewal announcement

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_690a00d9b6008325b53f083109e79a15