### PR TITLE
Add social metadata for site pages

### DIFF
--- a/games/games.html
+++ b/games/games.html
@@ -1,9 +1,21 @@
 <!doctype html>
 <html lang="ja">
-<head>
+  <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="ペンタスタジオが制作したボードゲームやマーダーミステリー、公演型謎解きのビジュアルを一覧で紹介。各タイトルの詳細ページやダウンロード先へアクセスでき、イベント持ち込みや委託販売の確認にも役立つゲームギャラリーです。プレイ人数や世界観の雰囲気を画像から一目で把握できます。" />
+  <meta property="og:title" content="Games – Pentas Studio" />
+  <meta property="og:description" content="ペンタスタジオが制作したボードゲームやマーダーミステリー、公演型謎解きのビジュアルを一覧で紹介。各タイトルの詳細ページやダウンロード先へアクセスでき、イベント持ち込みや委託販売の確認にも役立つゲームギャラリーです。プレイ人数や世界観の雰囲気を画像から一目で把握できます。" />
+  <meta property="og:image" content="https://www.pentas-studio.com/image/general/logo.png" />
+  <meta property="og:url" content="https://www.pentas-studio.com/games/games.html" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Games – Pentas Studio" />
+  <meta name="twitter:description" content="ペンタスタジオが制作したボードゲームやマーダーミステリー、公演型謎解きのビジュアルを一覧で紹介。各タイトルの詳細ページやダウンロード先へアクセスでき、イベント持ち込みや委託販売の確認にも役立つゲームギャラリーです。プレイ人数や世界観の雰囲気を画像から一目で把握できます。" />
+  <meta name="twitter:image" content="https://www.pentas-studio.com/image/general/logo.png" />
+  <meta name="twitter:url" content="https://www.pentas-studio.com/games/games.html" />
   <title>Games – Pentas Studio</title>
+  <link rel="canonical" href="https://www.pentas-studio.com/games/games.html" />
   <link rel="icon" type="image/png" href="../image/general/logo.png" />
   <link href="https://fonts.googleapis.com/css2?family=Rampart+One&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@500;700&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,19 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="description" content="Pentas Studioはボードゲーム、マーダーミステリー、謎解き公演を企画制作するクリエイティブチーム。代表作や最新ニュース、イベント出展予定、メンバー紹介、作品販売リンク、活動理念、制作の裏話、コミュニティへの参加方法をまとめた公式ポータルサイトです。" />
+<meta property="og:title" content="Pentas Studio" />
+<meta property="og:description" content="Pentas Studioはボードゲーム、マーダーミステリー、謎解き公演を企画制作するクリエイティブチーム。代表作や最新ニュース、イベント出展予定、メンバー紹介、作品販売リンク、活動理念、制作の裏話、コミュニティへの参加方法をまとめた公式ポータルサイトです。" />
+<meta property="og:image" content="https://www.pentas-studio.com/image/general/logo.png" />
+<meta property="og:url" content="https://www.pentas-studio.com/" />
+<meta property="og:type" content="website" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Pentas Studio" />
+<meta name="twitter:description" content="Pentas Studioはボードゲーム、マーダーミステリー、謎解き公演を企画制作するクリエイティブチーム。代表作や最新ニュース、イベント出展予定、メンバー紹介、作品販売リンク、活動理念、制作の裏話、コミュニティへの参加方法をまとめた公式ポータルサイトです。" />
+<meta name="twitter:image" content="https://www.pentas-studio.com/image/general/logo.png" />
+<meta name="twitter:url" content="https://www.pentas-studio.com/" />
 <title>Pentas Studio</title>
+<link rel="canonical" href="https://www.pentas-studio.com/" />
 <link rel="icon" type="image/png" href="./image/general/logo.png" />
 <link href="https://fonts.googleapis.com/css2?family=Rampart+One&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add rich meta description and social share tags to the home page
- add matching Open Graph, Twitter, and canonical metadata for the games listing page

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f247cbdc4832580e321da75904e84)